### PR TITLE
rh-che #557: Adding property and handler for stopping k8s / openshift workspace if unrecoverable event occurs during workspace startup

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -353,6 +353,10 @@ che.infra.kubernetes.workspace_start_timeout_min=8
 # Defines the timeout in minutes that limits the period for which Kubernetes Ingress become ready
 che.infra.kubernetes.ingress_start_timeout_min=5
 
+# If during workspace startup an unrecoverable event defined in the property occurs,
+# terminate workspace immediately instead of waiting until timeout
+che.infra.kubernetes.workspace_unrecoverable_events=Failed Mount,Failed Scheduling,Failed to pull image
+
 che.infra.kubernetes.bootstrapper.binary_url=http://${CHE_HOST}:${CHE_PORT}/agent-binaries/linux_amd64/bootstrapper/bootstrapper
 che.infra.kubernetes.bootstrapper.installer_timeout_sec=180
 che.infra.kubernetes.bootstrapper.server_check_period_sec=3

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesPods.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesPods.java
@@ -325,6 +325,7 @@ public class KubernetesPods {
                       new ContainerEvent(
                           podName,
                           containerName,
+                          event.getReason(),
                           event.getMessage(),
                           event.getMetadata().getCreationTimestamp());
                   containerEventsHandlers.forEach(h -> h.handle(containerEvent));
@@ -346,7 +347,7 @@ public class KubernetesPods {
   }
 
   /** Stops watching the pods inside Kubernetes namespace. */
-  void stopWatch() {
+  public void stopWatch() {
     try {
       if (podWatch != null) {
         podWatch.close();

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/event/ContainerEvent.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/event/ContainerEvent.java
@@ -21,12 +21,15 @@ import java.util.Objects;
 public class ContainerEvent {
   private final String podName;
   private final String containerName;
+  private final String reason;
   private final String message;
   private final String time;
 
-  public ContainerEvent(String podName, String containerName, String message, String time) {
+  public ContainerEvent(
+      String podName, String containerName, String reason, String message, String time) {
     this.podName = podName;
     this.containerName = containerName;
+    this.reason = reason;
     this.message = message;
     this.time = time;
   }
@@ -39,6 +42,11 @@ public class ContainerEvent {
   /** Returns container name which produced event. */
   public String getContainerName() {
     return containerName;
+  }
+
+  /** Returns the reason of the event. */
+  public String getReason() {
+    return reason;
   }
 
   /** Returns the contents of the event. */
@@ -62,13 +70,14 @@ public class ContainerEvent {
     ContainerEvent that = (ContainerEvent) o;
     return Objects.equals(podName, that.podName)
         && Objects.equals(containerName, that.containerName)
+        && Objects.equals(reason, that.reason)
         && Objects.equals(message, that.message)
         && Objects.equals(time, that.time);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(podName, containerName, message, time);
+    return Objects.hash(podName, containerName, reason, message, time);
   }
 
   @Override
@@ -79,6 +88,9 @@ public class ContainerEvent {
         + '\''
         + ", containerName='"
         + containerName
+        + '\''
+        + ", reason='"
+        + reason
         + '\''
         + ", message='"
         + message


### PR DESCRIPTION
### What does this PR do?
Adding property and handler for stopping k8s / openshift workspace if unrecoverable event occurs during workspace startup

Demo - https://youtu.be/J_DfNZXidE0

### What issues does this PR fix or reference?
https://github.com/redhat-developer/rh-che/issues/557

<!-- #### Changelog -->
Adding property `che.infra.kubernetes.workspace_unrecoverable_events`

if during workspace startup an unrecoverable event occurs (e.g. "Failed Mount" "Failed Scheduling") terminate workspace immediately instead of waiting util timeout

#### Release Notes
Adding property `che.infra.kubernetes.workspace_unrecoverable_events`

if during workspace startup an unrecoverable event occurs (e.g. "Failed Mount" "Failed Scheduling") terminate workspace immediately instead of waiting util timeout


#### Docs PR
https://github.com/eclipse/che-docs/pull/395