### PR TITLE
Skip authentication for the `OIDCKeycloak.js` file (Fix regression)

### DIFF
--- a/multiuser/keycloak/che-multiuser-keycloak-server/src/main/java/org/eclipse/che/multiuser/keycloak/server/AbstractKeycloakFilter.java
+++ b/multiuser/keycloak/che-multiuser-keycloak-server/src/main/java/org/eclipse/che/multiuser/keycloak/server/AbstractKeycloakFilter.java
@@ -38,14 +38,16 @@ public abstract class AbstractKeycloakFilter implements Filter {
   /** when a request came from a machine with valid token then auth is not required */
   protected boolean shouldSkipAuthentication(HttpServletRequest request, String token) {
     if (token == null) {
+      if (request.getRequestURI() != null
+          && request.getRequestURI().endsWith("api/keycloak/OIDCKeycloak.js")) {
+        return true;
+      }
       return false;
     }
     try {
       final PublicKey publicKey = signatureKeyManager.getKeyPair().getPublic();
       final Jwt jwt = Jwts.parser().setSigningKey(publicKey).parse(token);
-      return MACHINE_TOKEN_KIND.equals(jwt.getHeader().get("kind"))
-          || (request.getRequestURI() != null
-              && request.getRequestURI().endsWith("api/keycloak/OIDCKeycloak.js"));
+      return MACHINE_TOKEN_KIND.equals(jwt.getHeader().get("kind"));
     } catch (ExpiredJwtException | MalformedJwtException | SignatureException ex) {
       // given token is not signed by particular signature key so it must be checked in another way
       return false;

--- a/multiuser/keycloak/che-multiuser-keycloak-server/src/test/java/org/eclipse/che/multiuser/keycloak/server/AbstractKeycloakFilterTest.java
+++ b/multiuser/keycloak/che-multiuser-keycloak-server/src/test/java/org/eclipse/che/multiuser/keycloak/server/AbstractKeycloakFilterTest.java
@@ -65,6 +65,13 @@ public class AbstractKeycloakFilterTest {
             .compact();
 
     when(signatureKeyManager.getKeyPair()).thenReturn(keyPair);
+    when(request.getRequestURI()).thenReturn(null);
+  }
+
+  @Test
+  public void testShouldSkipAuthWhenRetrievingOIDCKeycloakJsFile() {
+    when(request.getRequestURI()).thenReturn("https://localhost:8080/api/keycloak/OIDCKeycloak.js");
+    assertTrue(abstractKeycloakFilter.shouldSkipAuthentication(request, null));
   }
 
   @Test


### PR DESCRIPTION
### What does this PR do?

This PR fixes a regression found while working on issue https://github.com/redhat-developer/rh-che/issues/632

It appears that commit https://github.com/eclipse/che/commit/38ff5c084b5901960cc8825894e0677dd2ba93a7 broke the support of alternate OIDC providers by restricting access to the `api/keycloak/OIDCKeycloak.js` file.

### What issues does this PR fix or reference?

This PR is required in the context of issue https://github.com/redhat-developer/rh-che/issues/632
