### PR TITLE
Added secrets into K8s/OS environments

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntime.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntime.java
@@ -20,6 +20,7 @@ import com.google.inject.assistedinject.Assisted;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.extensions.Ingress;
 import io.fabric8.kubernetes.client.Watcher.Action;
@@ -462,6 +463,11 @@ public class KubernetesInternalRuntime<
    */
   protected void startMachines() throws InfrastructureException {
     KubernetesEnvironment k8sEnv = getContext().getEnvironment();
+
+    for (Secret secret : k8sEnv.getSecrets().values()) {
+      namespace.secrets().create(secret);
+    }
+
     List<Service> createdServices = new ArrayList<>();
     for (Service service : k8sEnv.getServices().values()) {
       createdServices.add(namespace.services().create(service));

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironment.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironment.java
@@ -12,6 +12,7 @@ package org.eclipse.che.workspace.infrastructure.kubernetes.environment;
 
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.extensions.Ingress;
 import java.util.ArrayList;
@@ -36,6 +37,7 @@ public class KubernetesEnvironment extends InternalEnvironment {
   private final Map<String, Service> services;
   private final Map<String, Ingress> ingresses;
   private final Map<String, PersistentVolumeClaim> persistentVolumeClaims;
+  private final Map<String, Secret> secrets;
 
   public KubernetesEnvironment(KubernetesEnvironment k8sEnv) {
     this(
@@ -45,7 +47,8 @@ public class KubernetesEnvironment extends InternalEnvironment {
         k8sEnv.getPods(),
         k8sEnv.getServices(),
         k8sEnv.getIngresses(),
-        k8sEnv.getPersistentVolumeClaims());
+        k8sEnv.getPersistentVolumeClaims(),
+        k8sEnv.getSecrets());
   }
 
   public static Builder builder() {
@@ -59,12 +62,14 @@ public class KubernetesEnvironment extends InternalEnvironment {
       Map<String, Pod> pods,
       Map<String, Service> services,
       Map<String, Ingress> ingresses,
-      Map<String, PersistentVolumeClaim> persistentVolumeClaims) {
+      Map<String, PersistentVolumeClaim> persistentVolumeClaims,
+      Map<String, Secret> secrets) {
     super(internalRecipe, machines, warnings);
     this.pods = pods;
     this.services = services;
     this.ingresses = ingresses;
     this.persistentVolumeClaims = persistentVolumeClaims;
+    this.secrets = secrets;
   }
 
   /** Returns pods that should be created when environment starts. */
@@ -87,6 +92,11 @@ public class KubernetesEnvironment extends InternalEnvironment {
     return persistentVolumeClaims;
   }
 
+  /** Returns secrets that should be created when environment starts. */
+  public Map<String, Secret> getSecrets() {
+    return secrets;
+  }
+
   public static class Builder {
     protected InternalRecipe internalRecipe;
     protected final Map<String, InternalMachineConfig> machines = new HashMap<>();
@@ -94,7 +104,8 @@ public class KubernetesEnvironment extends InternalEnvironment {
     protected final Map<String, Pod> pods = new HashMap<>();
     protected final Map<String, Service> services = new HashMap<>();
     protected final Map<String, Ingress> ingresses = new HashMap<>();
-    protected final Map<String, PersistentVolumeClaim> persistentVolumeClaims = new HashMap<>();
+    protected final Map<String, PersistentVolumeClaim> pvcs = new HashMap<>();
+    protected final Map<String, Secret> secrets = new HashMap<>();
 
     protected Builder() {}
 
@@ -129,13 +140,18 @@ public class KubernetesEnvironment extends InternalEnvironment {
     }
 
     public Builder setPersistentVolumeClaims(Map<String, PersistentVolumeClaim> pvcs) {
-      this.persistentVolumeClaims.putAll(pvcs);
+      this.pvcs.putAll(pvcs);
+      return this;
+    }
+
+    public Builder setSecrets(Map<String, Secret> secrets) {
+      this.secrets.putAll(secrets);
       return this;
     }
 
     public KubernetesEnvironment build() {
       return new KubernetesEnvironment(
-          internalRecipe, machines, warnings, pods, services, ingresses, persistentVolumeClaims);
+          internalRecipe, machines, warnings, pods, services, ingresses, pvcs, secrets);
     }
   }
 }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespace.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespace.java
@@ -15,6 +15,7 @@ import io.fabric8.kubernetes.api.model.DoneableServiceAccount;
 import io.fabric8.kubernetes.api.model.Namespace;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceAccount;
 import io.fabric8.kubernetes.api.model.extensions.Ingress;
@@ -62,6 +63,7 @@ public class KubernetesNamespace {
   private final KubernetesPersistentVolumeClaims pvcs;
   private final KubernetesIngresses ingresses;
   private final KubernetesClientFactory clientFactory;
+  private final KubernetesSecrets secrets;
 
   @VisibleForTesting
   protected KubernetesNamespace(
@@ -71,7 +73,8 @@ public class KubernetesNamespace {
       KubernetesPods pods,
       KubernetesServices services,
       KubernetesPersistentVolumeClaims pvcs,
-      KubernetesIngresses kubernetesIngresses) {
+      KubernetesIngresses kubernetesIngresses,
+      KubernetesSecrets secrets) {
     this.clientFactory = clientFactory;
     this.workspaceId = workspaceId;
     this.name = name;
@@ -79,6 +82,7 @@ public class KubernetesNamespace {
     this.services = services;
     this.pvcs = pvcs;
     this.ingresses = kubernetesIngresses;
+    this.secrets = secrets;
   }
 
   public KubernetesNamespace(
@@ -90,6 +94,7 @@ public class KubernetesNamespace {
     this.services = new KubernetesServices(name, workspaceId, clientFactory);
     this.pvcs = new KubernetesPersistentVolumeClaims(name, workspaceId, clientFactory);
     this.ingresses = new KubernetesIngresses(name, workspaceId, clientFactory);
+    this.secrets = new KubernetesSecrets(name, workspaceId, clientFactory);
   }
 
   /**
@@ -136,9 +141,14 @@ public class KubernetesNamespace {
     return ingresses;
   }
 
+  /** Returns object for managing {@link Secret} instances inside namespace. */
+  public KubernetesSecrets secrets() {
+    return secrets;
+  }
+
   /** Removes all object except persistent volume claims inside namespace. */
   public void cleanUp() throws InfrastructureException {
-    doRemove(ingresses::delete, services::delete, pods::delete);
+    doRemove(ingresses::delete, services::delete, pods::delete, secrets::delete);
   }
 
   /**

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesSecrets.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesSecrets.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.namespace;
+
+import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.CHE_WORKSPACE_ID_LABEL;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesObjectUtil.putLabel;
+
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientFactory;
+import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesInfrastructureException;
+
+/**
+ * Defines an internal API for managing {@link Secret} instances in {@link KubernetesPods#namespace
+ * predefined namespace}.
+ *
+ * @author Sergii Leshchenko
+ */
+public class KubernetesSecrets {
+  private final String namespace;
+  private final String workspaceId;
+  private final KubernetesClientFactory clientFactory;
+
+  KubernetesSecrets(String namespace, String workspaceId, KubernetesClientFactory clientFactory) {
+    this.namespace = namespace;
+    this.workspaceId = workspaceId;
+    this.clientFactory = clientFactory;
+  }
+
+  /**
+   * Creates specified secret.
+   *
+   * @param secret secret to create
+   * @throws InfrastructureException when any exception occurs
+   */
+  public void create(Secret secret) throws InfrastructureException {
+    putLabel(secret, CHE_WORKSPACE_ID_LABEL, workspaceId);
+    try {
+      clientFactory.create(workspaceId).secrets().inNamespace(namespace).create(secret);
+    } catch (KubernetesClientException e) {
+      throw new KubernetesInfrastructureException(e);
+    }
+  }
+
+  /**
+   * Deletes all existing secrets.
+   *
+   * @throws InfrastructureException when any exception occurs
+   */
+  public void delete() throws InfrastructureException {
+    try {
+      clientFactory
+          .create(workspaceId)
+          .secrets()
+          .inNamespace(namespace)
+          .withLabel(CHE_WORKSPACE_ID_LABEL, workspaceId)
+          .delete();
+    } catch (KubernetesClientException e) {
+      throw new KubernetesInfrastructureException(e);
+    }
+  }
+}

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntimeTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntimeTest.java
@@ -50,6 +50,7 @@ import io.fabric8.kubernetes.api.model.IntOrStringBuilder;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodSpec;
+import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServicePort;
 import io.fabric8.kubernetes.api.model.ServicePortBuilder;
@@ -111,6 +112,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.model.KubernetesServe
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesIngresses;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespace;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesPods;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesSecrets;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesServices;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.event.ContainerEvent;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.WorkspaceVolumesStrategy;
@@ -170,6 +172,7 @@ public class KubernetesInternalRuntimeTest {
   @Mock private KubernetesServices services;
   @Mock private KubernetesIngresses ingresses;
   @Mock private KubernetesPods pods;
+  @Mock private KubernetesSecrets secrets;
   @Mock private KubernetesBootstrapper bootstrapper;
   @Mock private WorkspaceVolumesStrategy volumesStrategy;
   @Mock private WorkspaceProbesFactory workspaceProbesFactory;
@@ -244,6 +247,7 @@ public class KubernetesInternalRuntimeTest {
     when(namespace.services()).thenReturn(services);
     when(namespace.ingresses()).thenReturn(ingresses);
     when(namespace.pods()).thenReturn(pods);
+    when(namespace.secrets()).thenReturn(secrets);
     when(bootstrapperFactory.create(any(), anyList(), any(), any(), any()))
         .thenReturn(bootstrapper);
     doReturn(
@@ -282,12 +286,14 @@ public class KubernetesInternalRuntimeTest {
                     mockContainer(CONTAINER_NAME_1, EXPOSED_PORT_1),
                     mockContainer(CONTAINER_NAME_2, EXPOSED_PORT_2, INTERNAL_PORT))));
     when(k8sEnv.getPods()).thenReturn(podsMap);
+    when(k8sEnv.getSecrets()).thenReturn(ImmutableMap.of("secret", new Secret()));
 
     internalRuntime.internalStart(emptyMap());
 
     verify(pods).create(any());
     verify(ingresses).create(any());
     verify(services).create(any());
+    verify(secrets).create(any());
     verify(namespace.pods(), times(2)).watchContainers(any());
     verify(bootstrapper, times(2)).bootstrapAsync();
     verify(eventService, times(4)).publish(any());

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironmentFactoryTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironmentFactoryTest.java
@@ -22,6 +22,8 @@ import static org.eclipse.che.workspace.infrastructure.kubernetes.environment.Ku
 import static org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironmentFactory.INGRESSES_IGNORED_WARNING_MESSAGE;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironmentFactory.PVC_IGNORED_WARNING_CODE;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironmentFactory.PVC_IGNORED_WARNING_MESSAGE;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironmentFactory.SECRET_IGNORED_WARNING_CODE;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironmentFactory.SECRET_IGNORED_WARNING_MESSAGE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -41,6 +43,7 @@ import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.extensions.Ingress;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.KubernetesListMixedOperation;
@@ -137,6 +140,21 @@ public class KubernetesEnvironmentFactoryTest {
     assertEquals(
         parsed.getWarnings().get(0),
         new WarningImpl(PVC_IGNORED_WARNING_CODE, PVC_IGNORED_WARNING_MESSAGE));
+  }
+
+  @Test
+  public void ignoreSecretsWhenRecipeContainsThem() throws Exception {
+    final List<HasMetadata> recipeObjects = singletonList(new Secret());
+    when(validatedObjects.getItems()).thenReturn(recipeObjects);
+
+    final KubernetesEnvironment parsed =
+        k8sEnvironmentFactory.doCreate(internalRecipe, emptyMap(), emptyList());
+
+    assertTrue(parsed.getPersistentVolumeClaims().isEmpty());
+    assertEquals(parsed.getWarnings().size(), 1);
+    assertEquals(
+        parsed.getWarnings().get(0),
+        new WarningImpl(SECRET_IGNORED_WARNING_CODE, SECRET_IGNORED_WARNING_MESSAGE));
   }
 
   @Test

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceTest.java
@@ -63,6 +63,7 @@ public class KubernetesNamespaceTest {
   @Mock private KubernetesServices services;
   @Mock private KubernetesIngresses ingresses;
   @Mock private KubernetesPersistentVolumeClaims pvcs;
+  @Mock private KubernetesSecrets secrets;
   @Mock private KubernetesClientFactory clientFactory;
   @Mock private KubernetesClient kubernetesClient;
   @Mock private NonNamespaceOperation namespaceOperation;
@@ -86,7 +87,7 @@ public class KubernetesNamespaceTest {
 
     k8sNamespace =
         new KubernetesNamespace(
-            clientFactory, WORKSPACE_ID, NAMESPACE, pods, services, pvcs, ingresses);
+            clientFactory, WORKSPACE_ID, NAMESPACE, pods, services, pvcs, ingresses, secrets);
   }
 
   @Test
@@ -123,6 +124,7 @@ public class KubernetesNamespaceTest {
     verify(ingresses).delete();
     verify(services).delete();
     verify(pods).delete();
+    verify(secrets).delete();
   }
 
   @Test

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesSecretsTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesSecretsTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.namespace;
+
+import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.CHE_WORKSPACE_ID_LABEL;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+import io.fabric8.kubernetes.api.model.DoneableSecret;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecretList;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.Watch;
+import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientFactory;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+/**
+ * Tests {@link KubernetesSecrets}.
+ *
+ * @author Sergii Leshchenko
+ */
+@Listeners(MockitoTestNGListener.class)
+public class KubernetesSecretsTest {
+
+  private static final String NAMESPACE = "namespace";
+  private static final String WORKSPACE_ID = "workspace123";
+
+  @Mock private KubernetesClient client;
+  @Mock private KubernetesClientFactory clientFactory;
+
+  @Mock
+  private MixedOperation<Secret, SecretList, DoneableSecret, Resource<Secret, DoneableSecret>>
+      secretsMixedOperation;
+
+  @Mock
+  private NonNamespaceOperation<
+          Secret, SecretList, DoneableSecret, Resource<Secret, DoneableSecret>>
+      nonNamespaceOperation;
+
+  @Mock
+  private FilterWatchListDeletable<Secret, SecretList, Boolean, Watch, Watcher<Secret>>
+      deletableList;
+
+  private KubernetesSecrets kubernetesSecrets;
+
+  @BeforeMethod
+  public void setUp() throws Exception {
+    kubernetesSecrets = new KubernetesSecrets("namespace", "workspace123", clientFactory);
+
+    when(clientFactory.create("workspace123")).thenReturn(client);
+
+    when(client.secrets()).thenReturn(secretsMixedOperation);
+    when(secretsMixedOperation.inNamespace(any())).thenReturn(nonNamespaceOperation);
+    when(nonNamespaceOperation.withLabel(any(), any())).thenReturn(deletableList);
+  }
+
+  @Test
+  public void testSecretCreation() throws Exception {
+    Secret secret = new Secret();
+
+    kubernetesSecrets.create(secret);
+
+    assertEquals(secret.getMetadata().getLabels().get(CHE_WORKSPACE_ID_LABEL), WORKSPACE_ID);
+    verify(secretsMixedOperation).inNamespace(NAMESPACE);
+    verify(nonNamespaceOperation).create(secret);
+  }
+
+  @Test
+  public void testSecretsRemoving() throws Exception {
+    kubernetesSecrets.delete();
+
+    verify(secretsMixedOperation).inNamespace(NAMESPACE);
+    verify(nonNamespaceOperation).withLabel(CHE_WORKSPACE_ID_LABEL, WORKSPACE_ID);
+    verify(deletableList).delete();
+  }
+}

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntime.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntime.java
@@ -13,6 +13,7 @@ package org.eclipse.che.workspace.infrastructure.openshift;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.assistedinject.Assisted;
 import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.openshift.api.model.Route;
 import java.util.ArrayList;
@@ -92,6 +93,11 @@ public class OpenShiftInternalRuntime extends KubernetesInternalRuntime<OpenShif
   @Override
   protected void startMachines() throws InfrastructureException {
     OpenShiftEnvironment osEnv = getContext().getEnvironment();
+
+    for (Secret secret : osEnv.getSecrets().values()) {
+      project.secrets().create(secret);
+    }
+
     List<Service> createdServices = new ArrayList<>();
     for (Service service : osEnv.getServices().values()) {
       createdServices.add(project.services().create(service));

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/environment/OpenShiftEnvironment.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/environment/OpenShiftEnvironment.java
@@ -12,6 +12,7 @@ package org.eclipse.che.workspace.infrastructure.openshift.environment;
 
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.extensions.Ingress;
 import io.fabric8.openshift.api.model.Route;
@@ -22,6 +23,7 @@ import org.eclipse.che.api.core.model.workspace.Warning;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalRecipe;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.Builder;
 
 /**
  * Holds objects of OpenShift environment.
@@ -50,9 +52,10 @@ public class OpenShiftEnvironment extends KubernetesEnvironment {
       Map<String, Pod> pods,
       Map<String, Service> services,
       Map<String, Ingress> ingresses,
-      Map<String, PersistentVolumeClaim> persistentVolumeClaims,
+      Map<String, PersistentVolumeClaim> pvcs,
+      Map<String, Secret> secrets,
       Map<String, Route> routes) {
-    super(internalRecipe, machines, warnings, pods, services, ingresses, persistentVolumeClaims);
+    super(internalRecipe, machines, warnings, pods, services, ingresses, pvcs, secrets);
     this.routes = routes;
   }
 
@@ -66,38 +69,51 @@ public class OpenShiftEnvironment extends KubernetesEnvironment {
 
     private Builder() {}
 
+    @Override
     public Builder setInternalRecipe(InternalRecipe internalRecipe) {
       this.internalRecipe = internalRecipe;
       return this;
     }
 
+    @Override
     public Builder setMachines(Map<String, InternalMachineConfig> machines) {
       this.machines.putAll(machines);
       return this;
     }
 
+    @Override
     public Builder setWarnings(List<Warning> warnings) {
       this.warnings.addAll(warnings);
       return this;
     }
 
+    @Override
     public Builder setPods(Map<String, Pod> pods) {
       this.pods.putAll(pods);
       return this;
     }
 
+    @Override
     public Builder setServices(Map<String, Service> services) {
       this.services.putAll(services);
       return this;
     }
 
+    @Override
     public Builder setIngresses(Map<String, Ingress> ingresses) {
       this.ingresses.putAll(ingresses);
       return this;
     }
 
+    @Override
     public Builder setPersistentVolumeClaims(Map<String, PersistentVolumeClaim> pvcs) {
-      this.persistentVolumeClaims.putAll(pvcs);
+      this.pvcs.putAll(pvcs);
+      return this;
+    }
+
+    @Override
+    public Builder setSecrets(Map<String, Secret> secrets) {
+      this.secrets.putAll(secrets);
       return this;
     }
 
@@ -108,14 +124,7 @@ public class OpenShiftEnvironment extends KubernetesEnvironment {
 
     public OpenShiftEnvironment build() {
       return new OpenShiftEnvironment(
-          internalRecipe,
-          machines,
-          warnings,
-          pods,
-          services,
-          ingresses,
-          persistentVolumeClaims,
-          routes);
+          internalRecipe, machines, warnings, pods, services, ingresses, pvcs, secrets, routes);
     }
   }
 }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/environment/OpenShiftEnvironmentFactory.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/environment/OpenShiftEnvironmentFactory.java
@@ -20,6 +20,7 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesList;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.openshift.api.model.DeploymentConfig;
 import io.fabric8.openshift.api.model.Route;
@@ -62,6 +63,10 @@ public class OpenShiftEnvironmentFactory extends InternalEnvironmentFactory<Open
   static final int PVC_IGNORED_WARNING_CODE = 4101;
   static final String PVC_IGNORED_WARNING_MESSAGE =
       "Persistent volume claims specified in OpenShift recipe are ignored.";
+
+  static final int SECRET_IGNORED_WARNING_CODE = 4102;
+  static final String SECRET_IGNORED_WARNING_MESSAGE =
+      "Secrets specified in OpenShift recipe are ignored.";
 
   private final OpenShiftClientFactory clientFactory;
   private final KubernetesEnvironmentValidator envValidator;
@@ -116,6 +121,7 @@ public class OpenShiftEnvironmentFactory extends InternalEnvironmentFactory<Open
     Map<String, Service> services = new HashMap<>();
     boolean isAnyRoutePresent = false;
     boolean isAnyPVCPresent = false;
+    boolean isAnySecretPresent = false;
     for (HasMetadata object : list.getItems()) {
       if (object instanceof DeploymentConfig) {
         throw new ValidationException("Supporting of deployment configs is not implemented yet.");
@@ -129,6 +135,8 @@ public class OpenShiftEnvironmentFactory extends InternalEnvironmentFactory<Open
         isAnyRoutePresent = true;
       } else if (object instanceof PersistentVolumeClaim) {
         isAnyPVCPresent = true;
+      } else if (object instanceof Secret) {
+        isAnySecretPresent = true;
       } else {
         throw new ValidationException(
             format("Found unknown object type '%s'", object.getMetadata()));
@@ -143,6 +151,10 @@ public class OpenShiftEnvironmentFactory extends InternalEnvironmentFactory<Open
       warnings.add(new WarningImpl(PVC_IGNORED_WARNING_CODE, PVC_IGNORED_WARNING_MESSAGE));
     }
 
+    if (isAnySecretPresent) {
+      warnings.add(new WarningImpl(SECRET_IGNORED_WARNING_CODE, SECRET_IGNORED_WARNING_MESSAGE));
+    }
+
     addRamLimitAttribute(machines, pods.values());
 
     OpenShiftEnvironment osEnv =
@@ -153,6 +165,7 @@ public class OpenShiftEnvironmentFactory extends InternalEnvironmentFactory<Open
             .setPods(pods)
             .setServices(services)
             .setPersistentVolumeClaims(new HashMap<>())
+            .setSecrets(new HashMap<>())
             .setRoutes(new HashMap<>())
             .build();
 

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProject.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProject.java
@@ -22,6 +22,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesI
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespace;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesPersistentVolumeClaims;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesPods;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesSecrets;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesServices;
 import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientFactory;
 
@@ -44,8 +45,9 @@ public class OpenShiftProject extends KubernetesNamespace {
       KubernetesServices services,
       OpenShiftRoutes routes,
       KubernetesPersistentVolumeClaims pvcs,
-      KubernetesIngresses ingresses) {
-    super(clientFactory, workspaceId, name, pods, services, pvcs, ingresses);
+      KubernetesIngresses ingresses,
+      KubernetesSecrets secrets) {
+    super(clientFactory, workspaceId, name, pods, services, pvcs, ingresses, secrets);
     this.clientFactory = clientFactory;
     this.routes = routes;
   }
@@ -82,7 +84,7 @@ public class OpenShiftProject extends KubernetesNamespace {
 
   /** Removes all object except persistent volume claims inside project. */
   public void cleanUp() throws InfrastructureException {
-    doRemove(routes::delete, services()::delete, pods()::delete);
+    doRemove(routes::delete, services()::delete, pods()::delete, secrets()::delete);
   }
 
   private void create(String projectName, KubernetesClient kubeClient, OpenShiftClient ocClient)

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntimeTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntimeTest.java
@@ -38,6 +38,7 @@ import io.fabric8.kubernetes.api.model.IntOrStringBuilder;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodSpec;
+import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServicePort;
 import io.fabric8.kubernetes.api.model.ServicePortBuilder;
@@ -70,6 +71,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.bootstrapper.Kubernet
 import org.eclipse.che.workspace.infrastructure.kubernetes.cache.KubernetesMachineCache;
 import org.eclipse.che.workspace.infrastructure.kubernetes.cache.KubernetesRuntimeStateCache;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesPods;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesSecrets;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesServices;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.WorkspaceVolumesStrategy;
 import org.eclipse.che.workspace.infrastructure.kubernetes.util.KubernetesSharedPool;
@@ -122,6 +124,7 @@ public class OpenShiftInternalRuntimeTest {
   @Mock private OpenShiftEnvironment osEnv;
   @Mock private OpenShiftProject project;
   @Mock private KubernetesServices services;
+  @Mock private KubernetesSecrets secrets;
   @Mock private OpenShiftRoutes routes;
   @Mock private KubernetesPods pods;
   @Mock private KubernetesBootstrapper bootstrapper;
@@ -191,6 +194,7 @@ public class OpenShiftInternalRuntimeTest {
     doNothing().when(project).cleanUp();
     when(project.services()).thenReturn(services);
     when(project.routes()).thenReturn(routes);
+    when(project.secrets()).thenReturn(secrets);
     when(project.pods()).thenReturn(pods);
     when(bootstrapperFactory.create(any(), anyList(), any(), any(), any()))
         .thenReturn(bootstrapper);
@@ -213,6 +217,7 @@ public class OpenShiftInternalRuntimeTest {
     when(osEnv.getServices()).thenReturn(allServices);
     when(osEnv.getRoutes()).thenReturn(allRoutes);
     when(osEnv.getPods()).thenReturn(allPods);
+    when(osEnv.getSecrets()).thenReturn(ImmutableMap.of("secret", new Secret()));
   }
 
   @Test
@@ -228,6 +233,7 @@ public class OpenShiftInternalRuntimeTest {
     verify(pods).create(any());
     verify(routes).create(any());
     verify(services).create(any());
+    verify(secrets).create(any());
 
     verify(project.pods(), times(2)).watchContainers(any());
     verify(eventService, times(2)).publish(any());

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/environment/OpenShiftEnvironmentFactoryTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/environment/OpenShiftEnvironmentFactoryTest.java
@@ -22,6 +22,8 @@ import static org.eclipse.che.workspace.infrastructure.openshift.environment.Ope
 import static org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironmentFactory.PVC_IGNORED_WARNING_MESSAGE;
 import static org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironmentFactory.ROUTES_IGNORED_WARNING_MESSAGE;
 import static org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironmentFactory.ROUTE_IGNORED_WARNING_CODE;
+import static org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironmentFactory.SECRET_IGNORED_WARNING_CODE;
+import static org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironmentFactory.SECRET_IGNORED_WARNING_MESSAGE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -41,6 +43,7 @@ import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.client.dsl.KubernetesListMixedOperation;
 import io.fabric8.kubernetes.client.dsl.RecreateFromServerGettable;
 import io.fabric8.openshift.api.model.Route;
@@ -139,6 +142,21 @@ public class OpenShiftEnvironmentFactoryTest {
     assertEquals(
         parsed.getWarnings().get(0),
         new WarningImpl(PVC_IGNORED_WARNING_CODE, PVC_IGNORED_WARNING_MESSAGE));
+  }
+
+  @Test
+  public void ignoreSecretsWhenRecipeContainsThem() throws Exception {
+    final List<HasMetadata> recipeObjects = singletonList(new Secret());
+    when(validatedObjects.getItems()).thenReturn(recipeObjects);
+
+    final OpenShiftEnvironment parsed =
+        osEnvironmentFactory.doCreate(internalRecipe, emptyMap(), emptyList());
+
+    assertTrue(parsed.getRoutes().isEmpty());
+    assertEquals(parsed.getWarnings().size(), 1);
+    assertEquals(
+        parsed.getWarnings().get(0),
+        new WarningImpl(SECRET_IGNORED_WARNING_CODE, SECRET_IGNORED_WARNING_MESSAGE));
   }
 
   @Test

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectTest.java
@@ -35,6 +35,7 @@ import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesIngresses;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesPersistentVolumeClaims;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesPods;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesSecrets;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesServices;
 import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientFactory;
 import org.mockito.Mock;
@@ -59,6 +60,7 @@ public class OpenShiftProjectTest {
   @Mock private OpenShiftRoutes routes;
   @Mock private KubernetesPersistentVolumeClaims pvcs;
   @Mock private KubernetesIngresses ingresses;
+  @Mock private KubernetesSecrets secrets;
   @Mock private OpenShiftClientFactory clientFactory;
   @Mock private OpenShiftClient openShiftClient;
   @Mock private KubernetesClient kubernetesClient;
@@ -83,7 +85,15 @@ public class OpenShiftProjectTest {
 
     openShiftProject =
         new OpenShiftProject(
-            clientFactory, WORKSPACE_ID, PROJECT_NAME, pods, services, routes, pvcs, ingresses);
+            clientFactory,
+            WORKSPACE_ID,
+            PROJECT_NAME,
+            pods,
+            services,
+            routes,
+            pvcs,
+            ingresses,
+            secrets);
   }
 
   @Test
@@ -122,6 +132,7 @@ public class OpenShiftProjectTest {
     verify(routes).delete();
     verify(services).delete();
     verify(pods).delete();
+    verify(secrets).delete();
   }
 
   @Test


### PR DESCRIPTION
### What does this PR do?
Adds secrets into K8s/OS environments.

Also, it reworks creation image pull secrets for workspace - previously there was only one image pull secret whole one namespace but it has security issues in multiuser mode and single namespace/project configured. So, now each workspace will use separated secret and it will be removed on workspace stopping.

### What issues does this PR fix or reference?
It is needed for https://github.com/eclipse/che/issues/10081 since configuration for JWTProxy will be provided by secrets.

#### Release Notes
N/A

#### Docs PR
N/A