### PR TITLE
[POC] Provide support of Dockerimage recipe in Workspace.Next

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInfraModule.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInfraModule.java
@@ -28,6 +28,7 @@ import org.eclipse.che.api.workspace.server.spi.environment.InternalEnvironmentF
 import org.eclipse.che.api.workspace.server.spi.provision.env.CheApiExternalEnvVarProvider;
 import org.eclipse.che.api.workspace.server.spi.provision.env.CheApiInternalEnvVarProvider;
 import org.eclipse.che.api.workspace.server.spi.provision.env.EnvVarProvider;
+import org.eclipse.che.api.workspace.server.wsnext.InternalEnvironmentConverter;
 import org.eclipse.che.api.workspace.server.wsnext.WorkspaceNextApplier;
 import org.eclipse.che.workspace.infrastructure.docker.environment.dockerimage.DockerImageEnvironment;
 import org.eclipse.che.workspace.infrastructure.docker.environment.dockerimage.DockerImageEnvironmentFactory;
@@ -54,6 +55,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.Singl
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.secure.DefaultSecureServersFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.secure.SecureServerExposerFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.secure.SecureServerExposerFactoryProvider;
+import org.eclipse.che.workspace.infrastructure.kubernetes.wsnext.DockerimageToK8sInternalEnvConverter;
 import org.eclipse.che.workspace.infrastructure.kubernetes.wsnext.KubernetesWorkspaceNextApplier;
 
 /** @author Sergii Leshchenko */
@@ -138,5 +140,8 @@ public class KubernetesInfraModule extends AbstractModule {
     secureServerExposerFactories
         .addBinding("default")
         .to(new TypeLiteral<DefaultSecureServersFactory<KubernetesEnvironment>>() {});
+
+
+    bind(InternalEnvironmentConverter.class).to(DockerimageToK8sInternalEnvConverter.class);
   }
 }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsnext/DockerimageToK8sInternalEnvConverter.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsnext/DockerimageToK8sInternalEnvConverter.java
@@ -1,0 +1,37 @@
+package org.eclipse.che.workspace.infrastructure.kubernetes.wsnext;
+
+import javax.inject.Inject;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.environment.InternalEnvironment;
+import org.eclipse.che.api.workspace.server.wsnext.InternalEnvironmentConverter;
+import org.eclipse.che.workspace.infrastructure.docker.environment.dockerimage.DockerImageEnvironment;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.convert.DockerImageEnvironmentConverter;
+
+/**
+ * Converts Dockerimage workspace environment to kubernetes environment.
+ * Other internal environments returns without changing.
+ *
+ * <p>Allows support of sidecar tooling flow on Dockerimage environments while it is directly
+ * implemented in the kubernetes environment only.
+ *
+ * @author Oleksandr Garagatyi
+ */
+public class DockerimageToK8sInternalEnvConverter implements InternalEnvironmentConverter {
+  private final DockerImageEnvironmentConverter dockerImageEnvConverter;
+
+  @Inject
+  public DockerimageToK8sInternalEnvConverter(
+      DockerImageEnvironmentConverter dockerImageEnvConverter) {
+    this.dockerImageEnvConverter = dockerImageEnvConverter;
+  }
+
+  @Override
+  public InternalEnvironment convert(InternalEnvironment internalEnvironment)
+      throws InfrastructureException {
+
+    if (internalEnvironment instanceof DockerImageEnvironment) {
+      return dockerImageEnvConverter.convert((DockerImageEnvironment) internalEnvironment);
+    }
+    return internalEnvironment;
+  }
+}

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsnext/DockerimageToK8sInternalEnvConverter.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsnext/DockerimageToK8sInternalEnvConverter.java
@@ -9,7 +9,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.environment.convert.D
 
 /**
  * Converts Dockerimage workspace environment to kubernetes environment.
- * Other internal environments returns without changing.
+ * Other internal environments are returned without changes.
  *
  * <p>Allows support of sidecar tooling flow on Dockerimage environments while it is directly
  * implemented in the kubernetes environment only.

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/InternalEnvironmentProvider.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/InternalEnvironmentProvider.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.workspace.server;
+
+import static java.lang.String.format;
+
+import java.util.Map;
+import java.util.Set;
+import javax.inject.Inject;
+import org.eclipse.che.api.core.NotFoundException;
+import org.eclipse.che.api.core.ValidationException;
+import org.eclipse.che.api.core.model.workspace.config.Environment;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.environment.InternalEnvironment;
+import org.eclipse.che.api.workspace.server.spi.environment.InternalEnvironmentFactory;
+
+/**
+ * Creates {@link InternalEnvironment} from provided environment configuration.
+ *
+ * @author Oleksandr Garagatyi
+ */
+public class InternalEnvironmentProvider {
+
+  private final Map<String, InternalEnvironmentFactory> environmentFactories;
+
+  @Inject
+  public InternalEnvironmentProvider(Map<String, InternalEnvironmentFactory> environmentFactories) {
+    this.environmentFactories = environmentFactories;
+  }
+
+  public Set<String> supportedRecipes() {
+    return environmentFactories.keySet();
+  }
+
+  public InternalEnvironment create(
+      Environment environment, Map<String, String> workspaceAttributes)
+      throws InfrastructureException, ValidationException, NotFoundException {
+
+    String recipeType = environment.getRecipe().getType();
+    InternalEnvironmentFactory factory = environmentFactories.get(recipeType);
+    if (factory == null) {
+      throw new NotFoundException(
+          format("InternalEnvironmentFactory is not configured for recipe type: '%s'", recipeType));
+    }
+    return factory.create(environment);
+  }
+}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/InternalEnvironmentProviderFactory.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/InternalEnvironmentProviderFactory.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.workspace.server;
+
+import org.eclipse.che.api.workspace.server.wsnext.SidecarBasedInternalEnvironmentProvider;
+
+/** @author Alexander Garagatyi */
+public class InternalEnvironmentProviderFactory {
+
+  private final Toggles toggles;
+  private final InternalEnvironmentProvider classicProvider;
+  private final SidecarBasedInternalEnvironmentProvider sidecarBasedProvider;
+
+  public InternalEnvironmentProviderFactory(
+      Toggles toggles,
+      InternalEnvironmentProvider classicProvider,
+      SidecarBasedInternalEnvironmentProvider sidecarBasedProvider) {
+    this.toggles = toggles;
+    this.classicProvider = classicProvider;
+    this.sidecarBasedProvider = sidecarBasedProvider;
+  }
+
+  public InternalEnvironmentProvider create() {
+    if (toggles.isEnabled("workspace-next")) {
+      // Add sidecar based tooling
+      return sidecarBasedProvider;
+    } else {
+      return classicProvider;
+    }
+  }
+
+  private static class Toggles {
+
+    public boolean isEnabled(String toggleName) {
+      return true;
+    }
+  }
+}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsnext/InternalEnvironmentConverter.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsnext/InternalEnvironmentConverter.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.workspace.server.wsnext;
+
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.environment.InternalEnvironment;
+
+/** @author Alexander Garagatyi */
+public interface InternalEnvironmentConverter {
+
+  /**
+   * Converts one {@link InternalEnvironment} to another. Might be useful to improve features
+   * compatibility between infrastructures and recipes.
+   *
+   * <p>May return the same {@link InternalEnvironment} that is passed or convert it into another.
+   *
+   * @param internalEnvironment environment to convert
+   * @return converted environment
+   */
+  InternalEnvironment convert(InternalEnvironment internalEnvironment)
+      throws InfrastructureException;
+}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsnext/SidecarBasedInternalEnvironmentProvider.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsnext/SidecarBasedInternalEnvironmentProvider.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.workspace.server.wsnext;
+
+import java.util.Collection;
+import java.util.Map;
+import org.eclipse.che.api.core.NotFoundException;
+import org.eclipse.che.api.core.ValidationException;
+import org.eclipse.che.api.core.model.workspace.config.Environment;
+import org.eclipse.che.api.workspace.server.InternalEnvironmentProvider;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.environment.InternalEnvironment;
+import org.eclipse.che.api.workspace.server.spi.environment.InternalEnvironmentFactory;
+import org.eclipse.che.api.workspace.server.wsnext.model.ChePlugin;
+
+/**
+ * @author Alexander Garagatyi
+ */
+public class SidecarBasedInternalEnvironmentProvider extends InternalEnvironmentProvider {
+  private final Map<String, WorkspaceNextApplier> workspaceNextAppliers;
+  private final WorkspaceNextObjectsRetriever workspaceNextObjectsRetriever;
+
+
+  public SidecarBasedInternalEnvironmentProvider(
+      Map<String, WorkspaceNextApplier> workspaceNextAppliers,
+      WorkspaceNextObjectsRetriever workspaceNextObjectsRetriever,
+      Map<String, InternalEnvironmentFactory> environmentFactories) {
+    super(environmentFactories);
+    this.workspaceNextAppliers = workspaceNextAppliers;
+    this.workspaceNextObjectsRetriever = workspaceNextObjectsRetriever;
+  }
+
+  @Override
+  public InternalEnvironment create(Environment environment,
+      Map<String, String> workspaceAttributes)
+      throws InfrastructureException, ValidationException, NotFoundException {
+
+    InternalEnvironment internalEnvironment = super.create(environment, workspaceAttributes);
+    String recipeType = environment.getRecipe().getType();
+    applyWorkspaceNext(internalEnvironment, workspaceAttributes, recipeType);
+
+    return internalEnvironment;
+  }
+
+  private void applyWorkspaceNext(
+      InternalEnvironment internalEnvironment,
+      Map<String, String> workspaceAttributes,
+      String recipeType)
+      throws InfrastructureException {
+    Collection<ChePlugin> chePlugins = workspaceNextObjectsRetriever.get(workspaceAttributes);
+    if (chePlugins.isEmpty()) {
+      return;
+    }
+    WorkspaceNextApplier wsNext = workspaceNextAppliers.get(recipeType);
+    if (wsNext == null) {
+      throw new InfrastructureException(
+          "Workspace.Next features are not supported for recipe type " + recipeType);
+    }
+    wsNext.apply(internalEnvironment, chePlugins);
+  }
+}

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimesTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimesTest.java
@@ -62,7 +62,6 @@ import org.eclipse.che.api.workspace.server.spi.RuntimeInfrastructure;
 import org.eclipse.che.api.workspace.server.spi.WorkspaceDao;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalEnvironment;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalEnvironmentFactory;
-import org.eclipse.che.api.workspace.server.wsnext.WorkspaceNextObjectsRetriever;
 import org.eclipse.che.api.workspace.shared.dto.RuntimeIdentityDto;
 import org.eclipse.che.api.workspace.shared.dto.event.RuntimeStatusEvent;
 import org.eclipse.che.core.db.DBInitializer;
@@ -94,8 +93,6 @@ public class WorkspaceRuntimesTest {
 
   @Mock private WorkspaceStatusCache statuses;
 
-  @Mock private WorkspaceNextObjectsRetriever workspaceNextObjectsRetriever;
-
   private RuntimeInfrastructure infrastructure;
 
   @Mock private InternalEnvironmentFactory<InternalEnvironment> testEnvFactory;
@@ -109,16 +106,14 @@ public class WorkspaceRuntimesTest {
     runtimes =
         new WorkspaceRuntimes(
             eventService,
-            ImmutableMap.of(TEST_ENVIRONMENT_TYPE, testEnvFactory),
+            new InternalEnvironmentProvider(ImmutableMap.of(TEST_ENVIRONMENT_TYPE, testEnvFactory)),
             infrastructure,
             sharedPool,
             workspaceDao,
             dbInitializer,
             probeScheduler,
             statuses,
-            lockService,
-            emptyMap(),
-            workspaceNextObjectsRetriever);
+            lockService);
   }
 
   @Test
@@ -200,16 +195,14 @@ public class WorkspaceRuntimesTest {
     WorkspaceRuntimes localRuntimes =
         new WorkspaceRuntimes(
             localEventService,
-            ImmutableMap.of(TEST_ENVIRONMENT_TYPE, testEnvFactory),
+            new InternalEnvironmentProvider(ImmutableMap.of(TEST_ENVIRONMENT_TYPE, testEnvFactory)),
             infrastructure,
             sharedPool,
             workspaceDao,
             dbInitializer,
             probeScheduler,
             statuses,
-            lockService,
-            emptyMap(),
-            workspaceNextObjectsRetriever);
+            lockService);
     localRuntimes.init();
     RuntimeIdentityDto identity =
         DtoFactory.newDto(RuntimeIdentityDto.class)
@@ -261,16 +254,14 @@ public class WorkspaceRuntimesTest {
         new WorkspaceRuntimes(
             runtimesStorage,
             eventService,
-            ImmutableMap.of(TEST_ENVIRONMENT_TYPE, testEnvFactory),
+            new InternalEnvironmentProvider(ImmutableMap.of(TEST_ENVIRONMENT_TYPE, testEnvFactory)),
             infrastructure,
             sharedPool,
             workspaceDao,
             dbInitializer,
             probeScheduler,
             statuses,
-            lockService,
-            emptyMap(),
-            workspaceNextObjectsRetriever);
+            lockService);
 
     // when
     localRuntimes.injectRuntime(workspace);
@@ -484,12 +475,12 @@ public class WorkspaceRuntimesTest {
     }
 
     @Override
-    protected void internalStop(Map stopOptions) throws InfrastructureException {
+    protected void internalStop(Map stopOptions) {
       throw new UnsupportedOperationException();
     }
 
     @Override
-    protected void internalStart(Map startOptions) throws InfrastructureException {
+    protected void internalStart(Map startOptions) {
       throw new UnsupportedOperationException();
     }
   }


### PR DESCRIPTION
### What does this PR do?
This PR won't be merged. When we agree on the design I'll close it and create another one that will be meant to be merged.

This PR adds support of Dockerimage recipe in Workspace.Next and refactors usage of Workspace.Next  objects in a way that separates it from the main codebase. 
It is an alternativive to  https://github.com/eclipse/che/pull/10092
PR is supposed to be reviewed in a commit-by-commit manner.
The first commit refactors usage of Workspace.Next:
- moves InternalEnvironment creation from WorkspaceRuntimes to a new separate component - InternalEnvironmentProvider.
- creates WS.NEXT implementation of InternalEnvironmentProvider - SidecarBasedInternalEnvironmentProvider. This implementation applies WS.NEXT objects to InternalEnvironment produced by InternalEnvironmentProvider.
- creates a factory InternalEnvironmentProviderFactory of InternalEnvironment that returns InternalEnvironmentProvider or SidecarBasedInternalEnvironmentProvider implementation based on feature toggle (hardcoded in POC, will be reworked to switching with a property)

The second commit:
- adds a concept of InternalEnvironmentConverter to SidecarBasedInternalEnvironmentProvider implementation only. This converter might convert one InternalEnvironment to another InternalEnvironment or pass it if conversion is not needed for the incoming environment.
- adds DockerimageToK8sInternalEnvConverter implementation of the converter in k8s infrastructure impl. DockerimageToK8sInternalEnvConverter converts Dockerimage InternalEnvironment to Kubernetes InternalEnvironment

Feature toggling is hardcoded in PR and if we agreed on the design I can add a property to toggle Workspace.Next support. 

### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
