### PR TITLE
Modified the injection framework to use String for the workspace temp…

### DIFF
--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/client/TestProjectServiceClient.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/client/TestProjectServiceClient.java
@@ -163,7 +163,7 @@ public class TestProjectServiceClient {
             format(
                     Resources.toString(getResource("projects/jdt-ls-project-files/project"), UTF_8),
                     projectName)
-                .getBytes());
+                .getBytes(UTF_8));
         write(dotClasspath, toByteArray(getResource("projects/jdt-ls-project-files/classpath")));
         ZipUtils.add(out, dotClasspath);
         ZipUtils.add(out, dotProject);

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/utils/WorkspaceDtoDeserializer.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/utils/WorkspaceDtoDeserializer.java
@@ -23,7 +23,6 @@ import javax.inject.Named;
 import org.eclipse.che.api.workspace.shared.dto.WorkspaceConfigDto;
 import org.eclipse.che.dto.server.DtoFactory;
 import org.eclipse.che.selenium.core.constant.Infrastructure;
-import org.eclipse.che.selenium.core.workspace.WorkspaceTemplate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,26 +41,27 @@ public class WorkspaceDtoDeserializer {
   @Named("che.infrastructure")
   private Infrastructure infrastructure;
 
-  public WorkspaceConfigDto deserializeWorkspaceTemplate(WorkspaceTemplate templateName) {
-    requireNonNull(templateName);
+  public WorkspaceConfigDto deserializeWorkspaceTemplate(String workspaceTemplateName) {
+    requireNonNull(workspaceTemplateName);
 
     try {
 
       URL url =
-          Resources.getResource(WorkspaceDtoDeserializer.class, getTemplateDirectory(templateName));
+          Resources.getResource(
+              WorkspaceDtoDeserializer.class, getTemplateDirectory(workspaceTemplateName));
       return DtoFactory.getInstance()
           .createDtoFromJson(Resources.toString(url, Charsets.UTF_8), WorkspaceConfigDto.class);
     } catch (IOException | IllegalArgumentException | JsonSyntaxException e) {
       LOG.error(
           "Fail to read workspace template {} for infrastructure {} because {} ",
-          templateName,
-          getTemplateDirectory(templateName),
+          workspaceTemplateName,
+          getTemplateDirectory(workspaceTemplateName),
           e.getMessage());
       throw new RuntimeException(e.getLocalizedMessage(), e);
     }
   }
 
-  private String getTemplateDirectory(WorkspaceTemplate template) {
+  private String getTemplateDirectory(String workspaceTemplateName) {
     String templateDirectoryName;
     switch (infrastructure) {
       case OSIO:
@@ -74,6 +74,6 @@ public class WorkspaceDtoDeserializer {
     }
 
     return String.format(
-        "/templates/workspace/%s/%s", templateDirectoryName, template.getTemplateFileName());
+        "/templates/workspace/%s/%s", templateDirectoryName, workspaceTemplateName);
   }
 }

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/workspace/CheTestWorkspaceProvider.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/workspace/CheTestWorkspaceProvider.java
@@ -81,6 +81,7 @@ public class CheTestWorkspaceProvider implements TestWorkspaceProvider {
     }
   }
 
+  @Override
   public TestWorkspace getWorkspace(String workspaceName, TestUser owner) {
     return new CheTestWorkspace(
         workspaceName, owner, testWorkspaceServiceClientFactory.create(owner));
@@ -88,9 +89,9 @@ public class CheTestWorkspaceProvider implements TestWorkspaceProvider {
 
   @Override
   public TestWorkspace createWorkspace(
-      TestUser owner, int memoryGB, WorkspaceTemplate template, boolean startAfterCreation)
+      TestUser owner, int memoryGB, String templateFileName, boolean startAfterCreation)
       throws Exception {
-    if (poolSize > 0 && hasDefaultValues(owner, memoryGB, template, startAfterCreation)) {
+    if (poolSize > 0 && hasDefaultValues(owner, memoryGB, templateFileName, startAfterCreation)) {
       return doGetWorkspaceFromPool();
     }
 
@@ -99,7 +100,7 @@ public class CheTestWorkspaceProvider implements TestWorkspaceProvider {
         owner,
         memoryGB,
         startAfterCreation,
-        workspaceDtoDeserializer.deserializeWorkspaceTemplate(template));
+        workspaceDtoDeserializer.deserializeWorkspaceTemplate(templateFileName));
   }
 
   public TestWorkspace createWorkspace(
@@ -209,9 +210,9 @@ public class CheTestWorkspaceProvider implements TestWorkspaceProvider {
   }
 
   private boolean hasDefaultValues(
-      TestUser testUser, int memoryGB, WorkspaceTemplate template, boolean startAfterCreation) {
+      TestUser testUser, int memoryGB, String templateFileName, boolean startAfterCreation) {
     return memoryGB == defaultMemoryGb
-        && WorkspaceTemplate.DEFAULT == template
+        && WorkspaceTemplate.DEFAULT.equals(templateFileName)
         && testUser.getEmail().equals(defaultUser.getEmail())
         && startAfterCreation;
   }

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/workspace/InjectTestWorkspace.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/workspace/InjectTestWorkspace.java
@@ -13,6 +13,7 @@ package org.eclipse.che.selenium.core.workspace;
 
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.eclipse.che.selenium.core.workspace.WorkspaceTemplate.DEFAULT;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
@@ -22,7 +23,7 @@ import org.eclipse.che.selenium.core.user.TestUser;
 /**
  * To instantiate {@link TestWorkspace} in test classes with none default parameters.
  *
- * @see TestWorkspaceProvider#createWorkspace(TestUser, int, WorkspaceTemplate, boolean)
+ * @see TestWorkspaceProvider#createWorkspace(TestUser, int, String, boolean)
  * @author Anatolii Bazko
  */
 @Target({FIELD})
@@ -36,7 +37,7 @@ public @interface InjectTestWorkspace {
   int memoryGb() default -1;
 
   /** Workspace template to create workspace base upon. */
-  WorkspaceTemplate template() default WorkspaceTemplate.DEFAULT;
+  String template() default DEFAULT;
 
   /** The workspace owner. If value is empty then default user will be used. */
   String user() default "";

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/workspace/TestWorkspaceProvider.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/workspace/TestWorkspaceProvider.java
@@ -25,11 +25,11 @@ public interface TestWorkspaceProvider {
    *
    * @param owner the workspace owner
    * @param memoryGB the workspace memory size in GB
-   * @param template the workspace template {@link WorkspaceTemplate}
+   * @param templateFileName the workspace template file name {@link WorkspaceTemplate}
    * @param startAfterCreation start workspace just after creation, if <bold>true</bold>
    */
   TestWorkspace createWorkspace(
-      TestUser owner, int memoryGB, WorkspaceTemplate template, boolean startAfterCreation)
+      TestUser owner, int memoryGB, String templateFileName, boolean startAfterCreation)
       throws Exception;
 
   /**

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/workspace/WorkspaceTemplate.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/workspace/WorkspaceTemplate.java
@@ -16,29 +16,21 @@ package org.eclipse.che.selenium.core.workspace;
  *
  * @author Dmytro Nochevnov
  */
-public enum WorkspaceTemplate {
-  BROKEN("broken_workspace.json"),
-  DEFAULT("default.json"),
-  DEFAULT_WITH_GITHUB_PROJECTS("default_with_github_projects.json"),
-  ECLIPSE_PHP("eclipse_php.json"),
-  ECLIPSE_NODEJS("eclipse_nodejs.json"),
-  ECLIPSE_CPP_GCC("eclipse_cpp_gcc.json"),
-  ECLIPSE_NODEJS_YAML("eclipse_nodejs_with_yaml_ls.json"),
-  PYTHON("ubuntu_python.json"),
-  NODEJS_WITH_JSON_LS("nodejs_with_json_ls.json"),
-  UBUNTU("ubuntu.json"),
-  UBUNTU_GO("ubuntu_go.json"),
-  UBUNTU_JDK8("ubuntu_jdk8.json"),
-  UBUNTU_LSP("ubuntu_with_c_sharp_lsp.json"),
-  APACHE_CAMEL("spring_boot_with_apache_camel_ls.json");
+public final class WorkspaceTemplate {
+  public static final String BROKEN = "broken_workspace.json";
+  public static final String DEFAULT = "default.json";
+  public static final String DEFAULT_WITH_GITHUB_PROJECTS = "default_with_github_projects.json";
+  public static final String ECLIPSE_PHP = "eclipse_php.json";
+  public static final String ECLIPSE_NODEJS = "eclipse_nodejs.json";
+  public static final String ECLIPSE_CPP_GCC = "eclipse_cpp_gcc.json";
+  public static final String ECLIPSE_NODEJS_YAML = "eclipse_nodejs_with_yaml_ls.json";
+  public static final String PYTHON = "ubuntu_python.json";
+  public static final String NODEJS_WITH_JSON_LS = "nodejs_with_json_ls.json";
+  public static final String UBUNTU = "ubuntu.json";
+  public static final String UBUNTU_GO = "ubuntu_go.json";
+  public static final String UBUNTU_JDK8 = "ubuntu_jdk8.json";
+  public static final String UBUNTU_LSP = "ubuntu_with_c_sharp_lsp.json";
+  public static final String APACHE_CAMEL = "spring_boot_with_apache_camel_ls.json";
 
-  private final String templateFileName;
-
-  WorkspaceTemplate(String templateFileName) {
-    this.templateFileName = templateFileName;
-  }
-
-  public String getTemplateFileName() {
-    return templateFileName;
-  }
+  public WorkspaceTemplate() {}
 }

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/workspace/WorkspaceTemplate.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/workspace/WorkspaceTemplate.java
@@ -32,5 +32,5 @@ public final class WorkspaceTemplate {
   public static final String UBUNTU_LSP = "ubuntu_with_c_sharp_lsp.json";
   public static final String APACHE_CAMEL = "spring_boot_with_apache_camel_ls.json";
 
-  public WorkspaceTemplate() {}
+  private WorkspaceTemplate() {}
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/languageserver/GolangFileEditingTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/languageserver/GolangFileEditingTest.java
@@ -29,7 +29,6 @@ import com.google.inject.Inject;
 import java.net.URL;
 import java.nio.file.Paths;
 import java.util.List;
-import java.util.Map;
 import org.eclipse.che.selenium.core.client.TestProjectServiceClient;
 import org.eclipse.che.selenium.core.project.ProjectTemplates;
 import org.eclipse.che.selenium.core.workspace.InjectTestWorkspace;
@@ -80,7 +79,7 @@ public class GolangFileEditingTest {
   };
 
   /** It is Map[node-name, Pair[tab-name, line-number]] */
-  private static final Map<String, Pair<String, Integer>> PROJECT_SYMBOL_EXPECTED_TEXT =
+  private static final ImmutableMap<String, Pair<String, Integer>> PROJECT_SYMBOL_EXPECTED_TEXT =
       ImmutableMap.of(
           "print/desktop-go-simple/format.go", Pair.of("format.go", 23),
           "Print/desktop-go-simple/print.go", Pair.of("print.go", 24));


### PR DESCRIPTION
…late instead of the enum

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Changes template referencing to String instead of locked down enum

### What issues does this PR fix or reference?

https://app.zenhub.com/workspace/o/redhat-developer/che-functional-tests/issues/294

#### Release Notes

#### Docs PR
