### PR TITLE
Refresh progress state for the each node during structure update

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/processes/panel/ProcessesPanelPresenter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/processes/panel/ProcessesPanelPresenter.java
@@ -908,6 +908,7 @@ public class ProcessesPanelPresenter extends BasePresenter
     view.removeProcessNode(childNode);
     machineTreeNode.getChildren().remove(childNode);
     view.setProcessesData(rootNode);
+    rootNode.getChildren().forEach(node -> refreshStopButtonState(node.getId()));
   }
 
   @Nullable


### PR DESCRIPTION
### What does this PR do?
This changes proposal adds small fix which allow process tree to update status for each node if the last one is process node and correct display stop process button.

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### What issues does this PR fix or reference?
#11746 
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A