### PR TITLE
Add support for Templates in OpenShift recipes

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironmentFactory.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironmentFactory.java
@@ -17,7 +17,6 @@ import com.google.common.annotations.VisibleForTesting;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.api.model.KubernetesList;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Secret;
@@ -98,10 +97,10 @@ public class KubernetesEnvironmentFactory
                 + "application/x-yaml, text/yaml, text/x-yaml");
     }
 
-    final KubernetesList list;
+    final List<HasMetadata> list;
     try {
-      list =
-          clientFactory.create().lists().load(new ByteArrayInputStream(content.getBytes())).get();
+      // Load list of Kubernetes objects into java List.
+      list = clientFactory.create().load(new ByteArrayInputStream(content.getBytes())).get();
     } catch (KubernetesClientException e) {
       // KubernetesClient wraps the error when a JsonMappingException occurs so we need the cause
       String message = e.getCause() == null ? e.getMessage() : e.getCause().getMessage();
@@ -120,7 +119,7 @@ public class KubernetesEnvironmentFactory
     Map<String, PersistentVolumeClaim> pvcs = new HashMap<>();
     Map<String, Secret> secrets = new HashMap<>();
     boolean isAnyIngressPresent = false;
-    for (HasMetadata object : list.getItems()) {
+    for (HasMetadata object : list) {
       checkNotNull(object.getKind(), "Environment contains object without specified kind field");
       checkNotNull(object.getMetadata(), "%s metadata must not be null", object.getKind());
       checkNotNull(object.getMetadata().getName(), "%s name must not be null", object.getKind());

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironmentFactoryTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironmentFactoryTest.java
@@ -34,9 +34,7 @@ import com.google.common.collect.ImmutableSet;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.api.model.Container;
-import io.fabric8.kubernetes.api.model.DoneableKubernetesList;
 import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.api.model.KubernetesList;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
@@ -56,11 +54,10 @@ import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.fabric8.kubernetes.api.model.extensions.IngressBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.dsl.KubernetesListMixedOperation;
-import io.fabric8.kubernetes.client.dsl.RecreateFromServerGettable;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.dsl.ParameterNamespaceListVisitFromServerGetDeleteRecreateWaitApplicable;
 import java.io.InputStream;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.eclipse.che.api.core.ValidationException;
@@ -95,8 +92,6 @@ public class KubernetesEnvironmentFactoryTest {
   @Mock private KubernetesClient client;
   @Mock private InternalEnvironment internalEnvironment;
   @Mock private InternalRecipe internalRecipe;
-  @Mock private KubernetesListMixedOperation listMixedOperation;
-  @Mock private KubernetesList parsedList;
   @Mock private InternalMachineConfig machineConfig1;
   @Mock private InternalMachineConfig machineConfig2;
   @Mock private MemoryAttributeProvisioner memoryProvisioner;
@@ -104,8 +99,8 @@ public class KubernetesEnvironmentFactoryTest {
   private Map<String, InternalMachineConfig> machines;
 
   @Mock
-  private RecreateFromServerGettable<KubernetesList, KubernetesList, DoneableKubernetesList>
-      serverGettable;
+  private ParameterNamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata, Boolean>
+      loadedRecipe;
 
   @BeforeMethod
   public void setup() throws Exception {
@@ -113,9 +108,7 @@ public class KubernetesEnvironmentFactoryTest {
         new KubernetesEnvironmentFactory(
             null, null, null, clientFactory, k8sEnvValidator, memoryProvisioner);
     when(clientFactory.create()).thenReturn(client);
-    when(client.lists()).thenReturn(listMixedOperation);
-    when(listMixedOperation.load(any(InputStream.class))).thenReturn(serverGettable);
-    when(serverGettable.get()).thenReturn(parsedList);
+    when(client.load(any(InputStream.class))).thenReturn(loadedRecipe);
     lenient().when(internalEnvironment.getRecipe()).thenReturn(internalRecipe);
     when(internalRecipe.getContentType()).thenReturn(YAML_RECIPE);
     when(internalRecipe.getContent()).thenReturn("recipe content");
@@ -129,7 +122,7 @@ public class KubernetesEnvironmentFactoryTest {
         new ServiceBuilder().withNewMetadata().withName("service1").endMetadata().build();
     Service service2 =
         new ServiceBuilder().withNewMetadata().withName("service2").endMetadata().build();
-    when(parsedList.getItems()).thenReturn(asList(service1, service2));
+    when(loadedRecipe.get()).thenReturn(asList(service1, service2));
 
     // when
     KubernetesEnvironment k8sEnv = k8sEnvFactory.doCreate(internalRecipe, emptyMap(), emptyList());
@@ -147,7 +140,7 @@ public class KubernetesEnvironmentFactoryTest {
         new PersistentVolumeClaimBuilder().withNewMetadata().withName("pvc1").endMetadata().build();
     PersistentVolumeClaim pvc2 =
         new PersistentVolumeClaimBuilder().withNewMetadata().withName("pvc2").endMetadata().build();
-    when(parsedList.getItems()).thenReturn(asList(pvc1, pvc2));
+    when(loadedRecipe.get()).thenReturn(asList(pvc1, pvc2));
 
     // when
     KubernetesEnvironment k8sEnv = k8sEnvFactory.doCreate(internalRecipe, emptyMap(), emptyList());
@@ -160,11 +153,11 @@ public class KubernetesEnvironmentFactoryTest {
 
   @Test
   public void ignoreIgressesWhenRecipeContainsThem() throws Exception {
-    final List<HasMetadata> objects =
-        asList(
-            new IngressBuilder().withNewMetadata().withName("ingress1").endMetadata().build(),
-            new IngressBuilder().withNewMetadata().withName("ingress2").endMetadata().build());
-    when(parsedList.getItems()).thenReturn(objects);
+    when(loadedRecipe.get())
+        .thenReturn(
+            asList(
+                new IngressBuilder().withNewMetadata().withName("ingress1").endMetadata().build(),
+                new IngressBuilder().withNewMetadata().withName("ingress2").endMetadata().build()));
 
     final KubernetesEnvironment parsed =
         k8sEnvFactory.doCreate(internalRecipe, emptyMap(), emptyList());
@@ -180,8 +173,7 @@ public class KubernetesEnvironmentFactoryTest {
   public void addSecretsWhenRecipeContainsThem() throws Exception {
     Secret secret =
         new SecretBuilder().withNewMetadata().withName("test-secret").endMetadata().build();
-    final List<HasMetadata> recipeObjects = singletonList(secret);
-    when(parsedList.getItems()).thenReturn(recipeObjects);
+    when(loadedRecipe.get()).thenReturn(singletonList(secret));
 
     final KubernetesEnvironment parsed =
         k8sEnvFactory.doCreate(internalRecipe, emptyMap(), emptyList());
@@ -196,8 +188,7 @@ public class KubernetesEnvironmentFactoryTest {
   public void addConfigMapsWhenRecipeContainsThem() throws Exception {
     ConfigMap configMap =
         new ConfigMapBuilder().withNewMetadata().withName("test-configmap").endMetadata().build();
-    final List<HasMetadata> recipeObjects = singletonList(configMap);
-    when(parsedList.getItems()).thenReturn(recipeObjects);
+    when(loadedRecipe.get()).thenReturn(singletonList(configMap));
 
     final KubernetesEnvironment parsed =
         k8sEnvFactory.doCreate(internalRecipe, emptyMap(), emptyList());
@@ -216,7 +207,7 @@ public class KubernetesEnvironmentFactoryTest {
             .endMetadata()
             .withSpec(new PodSpec())
             .build();
-    when(parsedList.getItems()).thenReturn(singletonList(pod));
+    when(loadedRecipe.get()).thenReturn(singletonList(pod));
 
     // when
     KubernetesEnvironment k8sEnv = k8sEnvFactory.doCreate(internalRecipe, emptyMap(), emptyList());
@@ -251,8 +242,7 @@ public class KubernetesEnvironmentFactoryTest {
             .endSpec()
             .build();
 
-    final List<HasMetadata> recipeObjects = singletonList(deployment);
-    when(parsedList.getItems()).thenReturn(recipeObjects);
+    when(loadedRecipe.get()).thenReturn(singletonList(deployment));
 
     // when
     final KubernetesEnvironment k8sEnv =
@@ -296,7 +286,7 @@ public class KubernetesEnvironmentFactoryTest {
             .withNewSpec()
             .endSpec()
             .build();
-    when(parsedList.getItems()).thenReturn(asList(deployment, pod));
+    when(loadedRecipe.get()).thenReturn(asList(deployment, pod));
 
     // when
     final KubernetesEnvironment k8sEnv =
@@ -313,13 +303,20 @@ public class KubernetesEnvironmentFactoryTest {
     assertEquals(k8sEnv.getPodsData().get("bare-pod").getSpec(), pod.getSpec());
   }
 
+  @Test(expectedExceptions = ValidationException.class)
+  public void exceptionOnRecipeLoadError() throws Exception {
+    when(loadedRecipe.get()).thenThrow(new KubernetesClientException("Could not parse recipe"));
+
+    k8sEnvFactory.doCreate(internalRecipe, emptyMap(), emptyList());
+  }
+
   @Test(
       expectedExceptions = ValidationException.class,
       expectedExceptionsMessageRegExp = "Environment contains object without specified kind field")
   public void exceptionOnObjectWithNoKindSpecified() throws Exception {
     HasMetadata object = mock(HasMetadata.class);
     when(object.getKind()).thenReturn(null);
-    when(parsedList.getItems()).thenReturn(singletonList(object));
+    when(loadedRecipe.get()).thenReturn(singletonList(object));
 
     k8sEnvFactory.doCreate(internalRecipe, emptyMap(), emptyList());
   }
@@ -331,7 +328,7 @@ public class KubernetesEnvironmentFactoryTest {
     HasMetadata object = mock(HasMetadata.class);
     when(object.getKind()).thenReturn("MyObject");
     when(object.getMetadata()).thenReturn(null);
-    when(parsedList.getItems()).thenReturn(singletonList(object));
+    when(loadedRecipe.get()).thenReturn(singletonList(object));
 
     k8sEnvFactory.doCreate(internalRecipe, emptyMap(), emptyList());
   }
@@ -343,7 +340,7 @@ public class KubernetesEnvironmentFactoryTest {
     HasMetadata object = mock(HasMetadata.class);
     when(object.getKind()).thenReturn("MyObject");
     when(object.getMetadata()).thenReturn(new ObjectMetaBuilder().withName(null).build());
-    when(parsedList.getItems()).thenReturn(singletonList(object));
+    when(loadedRecipe.get()).thenReturn(singletonList(object));
 
     k8sEnvFactory.doCreate(internalRecipe, emptyMap(), emptyList());
   }


### PR DESCRIPTION
### What does this PR do?
Add support for Templates as OpenShift recipes, with parameters
- If the parameter does not have a default value, it is substituted with
  an empty string
- If the parameter has a default value, it is substituted when launching
  the workspace
- Generated parameter values are not supported (see https://github.com/fabric8io/kubernetes-client/issues/1340)

This commit does not add dashboard validation (separate PR: https://github.com/eclipse/che/pull/12582), so starting a workspace based off a template requires manually editing an existing workspace config rather than creating a new stack.

The actual change is quite simple: the actual code difference amounts to
```java
clientFactory.create().load(new ByteArrayInputStream(content.getBytes())).get()
```
instead of
```java
clientFactory.create().lists().load(new ByteArrayInputStream(content.getBytes())).get()
```

Sample recipe:
```yaml
kind: Template
apiVersion: v1
metadata:
  name: template-test
objects:
- 
  apiVersion: v1
  kind: Pod
  metadata:
    name: ws
    labels:
      parameter: ${TEST}
  spec:
    containers:
    - 
      image: 'eclipse/che-dev:nightly'
      name: dev
      resources:
        limits:
        memory: 512Mi
parameters:
- name: TEST
  value: test
```

Above recipe formatted for pasting into existing config:
```
kind: Template\napiVersion: v1\nmetadata:\n  name: template-test\nobjects:\n- \n  apiVersion: v1\n  kind: Pod\n  metadata:\n    name: ws\n    labels:\n      parameter: ${TEST}\n  spec:\n    containers:\n    - \n      image: 'eclipse/che-dev:nightly'\n      name: dev\n      resources:\n        limits:\n        memory: 512Mi\nparameters:\n- name: TEST\n  value: test
```


### What issues does this PR fix or reference?
#11504 

#### Release Notes
Support OpenShift templates in workspace stack recipes.

#### Docs PR
Still TODO: docs need to be updated with routes/secrets/templates/etc. notes.
