### PR TITLE
Adding info to sumup file of load tests

### DIFF
--- a/tests/performance/load-tests.sh
+++ b/tests/performance/load-tests.sh
@@ -291,4 +291,4 @@ oc delete service load-tests-ftp-service
 oc delete pvc load-test-pvc
 
 # ----------- PROCESSING TEST RESULTS ----------- #
-$TEST_FOLDER/process-logs.sh -t $TIMESTAMP -f $FOLDER -u $users_assigned -c $COMPLETITIONS_COUNT
+$TEST_FOLDER/process-logs.sh -t $TIMESTAMP -f $FOLDER -u $users_assigned -c $COMPLETITIONS_COUNT -s $SERVER_SETTING -v $TEST_SUITE

--- a/tests/performance/process-logs.sh
+++ b/tests/performance/process-logs.sh
@@ -6,9 +6,11 @@ function printHelp {
   echo "-t     timestamp of the run"
   echo "-c     completitions count"
   echo "-u     users count"
+  echo "-s     server settings"
+  echo "-v     test suite"
 }
 
-while getopts "f:t:c:u:h" opt; do 
+while getopts "f:t:c:u:hs:v:" opt; do 
   case $opt in
     h) printHelp
       ;;
@@ -19,6 +21,10 @@ while getopts "f:t:c:u:h" opt; do
     c) export COMPLETITIONS_COUNT=$OPTARG
       ;;
     u) export USERS_COUNT=$OPTARG
+      ;;
+    s) export SERVER_SETTING=$OPTARG
+      ;;
+    v) export TEST_SUITE=$OPTARG
       ;;
     \?) # invalid option
       exit 1
@@ -40,7 +46,7 @@ echo "-- Generate sum-up for load tests."
 sumupFile="$FOLDER/$TIMESTAMP/load-test-sumup.txt"
 touch $sumupFile
 
-# write users with failed tests
+# gather users with failed tests
 failedUsers=""
 i=1
 failedCounter=0
@@ -61,11 +67,11 @@ done
 cd $CURRENT_DIR
 
 echo "Tests setup: $USERS_COUNT users, each running $COMPLETITIONS_COUNT workspaces" 
-echo -e "Tests setup: $USERS_COUNT users, each running $COMPLETITIONS_COUNT workspaces \n \n" > $sumupFile
+echo -e "Tests setup: \n  $USERS_COUNT users, each running $COMPLETITIONS_COUNT workspaces \n  Server settings: $SERVER_SETTING \n  Test suite used: $TEST_SUITE \n \n" > $sumupFile
 
 if [[ $failedUsers == "" ]]; then
   echo "All tests has passed, yay!"
-  echo -e "Tests passed for all $TEST_COUNT workspaces, yay! \n" > $sumupFile
+  echo -e "Tests passed for all $TEST_COUNT workspaces, yay! \n" >> $sumupFile
 else
   echo "Test failed for $failedCounter/$TEST_COUNT workspaces: $failedUsers"
   echo -e "Test failed for $failedCounter/$TEST_COUNT workspaces: $failedUsers \n" >> $sumupFile


### PR DESCRIPTION
### What does this PR do?
Change output for sumup file for load tests from this:

```
Tests setup: 10 users, each running 5 workspaces 
```

to this:
```
Tests setup: 
  10 users, each running 2 workspaces 
  Server settings: multi-host 
  Test suite used: load-test 
```

so now it's easier to get info about the setup of a current test.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-2105

### How to test this PR?
Run the load tests and check the sumup file in the report folder.


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
