### PR TITLE
Fix default repo branch for devworkspace happy path

### DIFF
--- a/tests/devworkspace-happy-path/remote-launch.sh
+++ b/tests/devworkspace-happy-path/remote-launch.sh
@@ -12,7 +12,7 @@
 # needed for running Che DevWorkspace Happy Path test which is located
 # remotely, like in another git repo
 set -e
-CHE_REPO_BRANCH="${CHE_REPO_BRANCH:-CHE-20421}"
+CHE_REPO_BRANCH="${CHE_REPO_BRANCH:-main}"
 CHE_REPO_ARCHIVE="${CHE_REPO_ARCHIVE:-https://github.com/eclipse/che/archive/refs/heads/${CHE_REPO_BRANCH}.zip}"
 
 prepareAndCloneCodebase(){
@@ -29,7 +29,6 @@ prepareAndCloneCodebase(){
     mkdir "$CODE_BASE_DIR"
   fi
 
-  CHE_REPO_ARCHIVE="https://github.com/eclipse/che/archive/refs/heads/CHE-20421.zip"
   echo "Downloading $CHE_REPO_ARCHIVE into $CODE_BASE_DIR"
   cd $CODE_BASE_DIR
   curl -f -L -sS ${CHE_REPO_ARCHIVE} > "${CODE_BASE_DIR}/archive.zip"


### PR DESCRIPTION
### What does this PR do?
Fix selecting default repo branch for **remote-launch.sh** test

### Screenshot/screencast of this PR



### What issues does this PR fix or reference?

### How to test this PR


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
