### PR TITLE
Ignore 'redhat.fabric8-analytics' VSIX extension in DS 3.22.x tests

### DIFF
--- a/tests/e2e/specs/dashboard-samples/RecommendedExtensions.spec.ts
+++ b/tests/e2e/specs/dashboard-samples/RecommendedExtensions.spec.ts
@@ -298,8 +298,8 @@ for (const sample of samples) {
 
 			Logger.debug('recommendedExtensions.recommendations: Get recommendations clear names using map().');
 
-			// skip the test if only redhat.fabric8-analytics extension is found in Dev Spaces 3.22.0 (issue CRW-9186)
-			if (BASE_TEST_CONSTANTS.OCP_VERSION === '3.22.0' && BASE_TEST_CONSTANTS.TESTING_APPLICATION_NAME() === 'devspaces') {
+			// skip the test if only redhat.fabric8-analytics extension is found in Dev Spaces 3.22.x (issue CRW-9186)
+			if (BASE_TEST_CONSTANTS.TESTING_APPLICATION_NAME() === 'devspaces' && BASE_TEST_CONSTANTS.TESTING_APPLICATION_VERSION.startsWith('3.22')) {
 				const dependencyAnalyticsExtensionName: string = 'redhat.fabric8-analytics';
 				if (
 					recommendedExtensions.recommendations.includes(dependencyAnalyticsExtensionName) &&


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Ignores 'redhat.fabric8-analytics' VSIX extension in DS 3.22.x recommended extensions test.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?
It's a workaround to issue https://issues.redhat.com/browse/CRW-9186

### How to test this PR?
Run Quarkus REST API RecommendedExtensions test.
Here is [a successful test run](https://jenkins-csb-crwqe-main.dno.corp.redhat.com/job/Testing/job/e2e/job/basic/job/typescript-tests/39807/).

```
    ✔ Check if extensions are installed and enabled
          ▼ Dashboard.openDashboard
            ‣ DriverHelper.navigateToUrl
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
      • Dashboard.openDashboard - Alert detected, text: ""
          ▼ Dashboard.openDashboard - Alert accepting
          ▼ Dashboard.waitPage
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 2000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #2, retrying with 2000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ BrowserTabsUtil.closeAllTabsExceptCurrent
          ▼ BrowserTabsUtil.getAllWindowHandles
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.getCurrentWindowHandle
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.switchToWindow
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.switchToWindow
            ‣ DriverHelper.getDriver
          ▼ TestWorkspaceUtil.stopAndDeleteWorkspaceByName
          ▼ TestWorkspaceUtil.stopWorkspaceByName - quarkus-quickstart
          ▼ ApiUrlResolver.obtainUserNamespace
            ‣ ApiUrlResolver.obtainUserNamespace - USER_NAMESPACE.length = 0, calling kubernetes API
            ‣ DriverHelper.getDriver
          ▼ ApiUrlResolver.obtainUserNamespace - kubeapi success: admin-devspaces
            ‣ DriverHelper.getDriver
          ▼ TestWorkspaceUtil.waitWorkspaceStatus
          ▼ ApiUrlResolver.obtainUserNamespace - admin-devspaces
            ‣ DriverHelper.getDriver
          ▼ TestWorkspaceUtil.stopWorkspaceByName - quarkus-quickstart stopped successfully
          ▼ TestWorkspaceUtil.deleteWorkspaceByName - quarkus-quickstart
          ▼ ApiUrlResolver.obtainUserNamespace - admin-devspaces
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
          ▼ TestWorkspaceUtil.deleteWorkspaceByName - quarkus-quickstart deleted successfully
          ▼     at /home/ndp/projects/che/tests/e2e/specs/MochaHooks.ts:39:12 - delete workspace name


  10 passing (7m)
```

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
