### PR TITLE
[Test] Add automated test case for vscode extension activation

### DIFF
--- a/tests/e2e/CODE_STYLE.md
+++ b/tests/e2e/CODE_STYLE.md
@@ -28,6 +28,7 @@ Automated lint checking and code format performs with ESLint and Prettier tools 
 ### Preferable code style
 
 1. Page-object and util classes
+
     1. ✔ Class declaration using dependency injection (inversify library)
 
         ```
@@ -37,6 +38,7 @@ Automated lint checking and code format performs with ESLint and Prettier tools 
         ```
 
     2. Public methods
+
         - ✔ Declare public methods without "public "keyword
         - ✔ Add Logger.debug() inside method to log its name (with optional message)
 
@@ -49,6 +51,7 @@ Automated lint checking and code format performs with ESLint and Prettier tools 
         ```
 
     3. Locators
+
         - ✔ For static locators - private static readonly fields type of By
 
         ```
@@ -102,6 +105,7 @@ Automated lint checking and code format performs with ESLint and Prettier tools 
         ```
 
 2. Mocha framework
+
     - ✔ TDD framework (`suite()`, `test()`)
     - ✔ Inject class instances, declare all test data inside test `suit()` function to avoid unnecessary code execution if test suit will not be run
 
@@ -118,6 +122,7 @@ Automated lint checking and code format performs with ESLint and Prettier tools 
     - ✔ Use test [./constants](constants) to make test flexible
 
 3. Packages
+
     1. Add packages as dev dependencies
     2. If any changes re-create package-lock.json before push
 

--- a/tests/e2e/pageobjects/dashboard/Workspaces.ts
+++ b/tests/e2e/pageobjects/dashboard/Workspaces.ts
@@ -240,7 +240,7 @@ export class Workspaces {
 	}
 
 	private getOpenButtonLocator(workspaceName: string): By {
-		return By.xpath(`${this.getWorkspaceListItemLocator(workspaceName).value}//td[@data-key=5]//a[text()='Open']`);
+		return By.xpath(`${this.getWorkspaceListItemLocator(workspaceName).value}//td[@data-key=5]//button[text()='Open']`);
 	}
 
 	private getOpenWorkspaceDetailsLinkLocator(workspaceName: string): By {

--- a/tests/e2e/specs/miscellaneous/ExtensionActivationTest.spec.ts
+++ b/tests/e2e/specs/miscellaneous/ExtensionActivationTest.spec.ts
@@ -1,0 +1,166 @@
+/** *******************************************************************
+ * copyright (c) 2025 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+import { e2eContainer } from '../../configs/inversify.config';
+import { CLASSES, TYPES } from '../../configs/inversify.types';
+import { WorkspaceHandlingTests } from '../../tests-library/WorkspaceHandlingTests';
+import { ProjectAndFileTests } from '../../tests-library/ProjectAndFileTests';
+import { LoginTests } from '../../tests-library/LoginTests';
+import { registerRunningWorkspace } from '../MochaHooks';
+import { expect } from 'chai';
+
+import { DriverHelper } from '../../utils/DriverHelper';
+import { BrowserTabsUtil } from '../../utils/BrowserTabsUtil';
+import { Dashboard } from '../../pageobjects/dashboard/Dashboard';
+import { ITestWorkspaceUtil } from '../../utils/workspace/ITestWorkspaceUtil';
+import { TIMEOUT_CONSTANTS } from '../../constants/TIMEOUT_CONSTANTS';
+
+import { By } from 'selenium-webdriver';
+import { BASE_TEST_CONSTANTS } from '../../constants/BASE_TEST_CONSTANTS';
+import { ViewSection } from 'monaco-page-objects';
+import { Workspaces } from '../../pageobjects/dashboard/Workspaces';
+
+suite(`Extension Activation Test ${BASE_TEST_CONSTANTS.TEST_ENVIRONMENT}`, function (): void {
+	const workspaceHandlingTests: WorkspaceHandlingTests = e2eContainer.get(CLASSES.WorkspaceHandlingTests);
+	const projectAndFileTests: ProjectAndFileTests = e2eContainer.get(CLASSES.ProjectAndFileTests);
+	const loginTests: LoginTests = e2eContainer.get(CLASSES.LoginTests);
+	const driverHelper: DriverHelper = e2eContainer.get(CLASSES.DriverHelper);
+	const browserTabsUtil: BrowserTabsUtil = e2eContainer.get(CLASSES.BrowserTabsUtil);
+	const dashboard: Dashboard = e2eContainer.get(CLASSES.Dashboard);
+	const testWorkspaceUtil: ITestWorkspaceUtil = e2eContainer.get(TYPES.WorkspaceUtil);
+	const workspaces: Workspaces = e2eContainer.get(CLASSES.Workspaces);
+
+	const FACTORY_URL: string = 'https://github.com/crw-qe/python-hello-world/tree/test-vscode-extensions';
+	const PROJECT_NAME: string = 'python-hello-world';
+	const PYTHON_FILE_NAME: string = 'hello-world.py';
+	const RUN_PYTHON_BUTTON: By = By.xpath('//a[@aria-label="Run Python File"]');
+	const TERMINAL_OUTPUT: By = By.className('xterm-screen');
+	const OUTPUT_PANEL_TAB: By = By.xpath('//a[contains(@aria-label, "Output")]');
+	const PYTHON_OUTPUT_OPTION: By = By.xpath('//option[text()="Python"]');
+	const MONACO_SELECT_BOX: By = By.css('select.monaco-select-box');
+	const OUTPUT_PANEL_CONTENT: By = By.xpath('//div[contains(@class, "output")]//div[contains(@class, "view-lines")]');
+	const WORKSPACE_RESTART_TIMEOUT: number = 300000;
+
+	let workspaceName: string = '';
+
+	suiteSetup('Login to DevSpaces', async function (): Promise<void> {
+		await loginTests.loginIntoChe();
+	});
+
+	test('Create and open workspace from factory URL', async function (): Promise<void> {
+		await workspaceHandlingTests.createAndOpenWorkspaceFromGitRepository(FACTORY_URL);
+		await workspaceHandlingTests.obtainWorkspaceNameFromStartingPage();
+		workspaceName = WorkspaceHandlingTests.getWorkspaceName();
+		expect(workspaceName, 'Workspace name was not detected').not.empty;
+		registerRunningWorkspace(workspaceName);
+	});
+
+	test('Wait for workspace readiness and handle trust dialogs', async function (): Promise<void> {
+		await projectAndFileTests.waitWorkspaceReadinessForCheCodeEditor();
+		await projectAndFileTests.performTrustDialogs();
+	});
+
+	test('Open Python file and run it', async function (): Promise<void> {
+		const projectSection: ViewSection = await projectAndFileTests.getProjectViewSession();
+		await projectSection.openItem(PROJECT_NAME, PYTHON_FILE_NAME);
+		await driverHelper.wait(TIMEOUT_CONSTANTS.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
+
+		await driverHelper.waitAndClick(RUN_PYTHON_BUTTON);
+		await driverHelper.wait(TIMEOUT_CONSTANTS.TS_DIALOG_WINDOW_DEFAULT_TIMEOUT);
+	});
+
+	test('Check terminal output shows "Hello, world!"', async function (): Promise<void> {
+		const terminalOutput: string = await driverHelper.waitAndGetText(TERMINAL_OUTPUT, TIMEOUT_CONSTANTS.TS_COMMON_PLUGIN_TEST_TIMEOUT);
+
+		expect(terminalOutput).to.include('Hello, world!');
+	});
+
+	test('Check Output panel for Python activation errors', async function (): Promise<void> {
+		await driverHelper.waitAndClick(OUTPUT_PANEL_TAB);
+		await driverHelper.wait(TIMEOUT_CONSTANTS.TS_SELENIUM_DEFAULT_POLLING);
+
+		await driverHelper.waitAndClick(MONACO_SELECT_BOX);
+		await driverHelper.waitAndClick(PYTHON_OUTPUT_OPTION);
+		await driverHelper.wait(TIMEOUT_CONSTANTS.TS_SELENIUM_DEFAULT_POLLING);
+
+		const outputText: string = await driverHelper.waitAndGetText(OUTPUT_PANEL_CONTENT, TIMEOUT_CONSTANTS.TS_COMMON_PLUGIN_TEST_TIMEOUT);
+
+		expect(outputText).to.not.include('Failed to activate a workspace');
+		expect(outputText).to.not.include('Missing required @injectable annotation');
+	});
+
+	test('Refresh page and verify extension still works', async function (): Promise<void> {
+		await browserTabsUtil.refreshPage();
+		await projectAndFileTests.waitWorkspaceReadinessForCheCodeEditor();
+		await driverHelper.wait(TIMEOUT_CONSTANTS.TS_IDE_LOAD_TIMEOUT);
+
+		const projectSection: ViewSection = await projectAndFileTests.getProjectViewSession();
+		await projectSection.openItem(PROJECT_NAME, PYTHON_FILE_NAME);
+		await driverHelper.wait(TIMEOUT_CONSTANTS.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
+
+		await driverHelper.waitAndClick(RUN_PYTHON_BUTTON);
+		await driverHelper.wait(TIMEOUT_CONSTANTS.TS_DIALOG_WINDOW_DEFAULT_TIMEOUT);
+
+		const terminalOutput: string = await driverHelper.waitAndGetText(TERMINAL_OUTPUT, TIMEOUT_CONSTANTS.TS_COMMON_PLUGIN_TEST_TIMEOUT);
+		expect(terminalOutput).to.include('Hello, world!');
+
+		await driverHelper.waitAndClick(OUTPUT_PANEL_TAB);
+		const outputText: string = await driverHelper.waitAndGetText(OUTPUT_PANEL_CONTENT, TIMEOUT_CONSTANTS.TS_COMMON_PLUGIN_TEST_TIMEOUT);
+		expect(outputText).to.not.include('Failed to activate a workspace');
+	});
+
+	test('Stop workspace', async function (): Promise<void> {
+		const currentWorkspaceName: string = WorkspaceHandlingTests.getWorkspaceName();
+		expect(currentWorkspaceName, 'Workspace name not available').not.empty;
+
+		await dashboard.openDashboard();
+		await dashboard.waitPage();
+		await dashboard.stopWorkspaceByUI(currentWorkspaceName);
+	});
+
+	test('Start workspace after stop', async function (): Promise<void> {
+		this.timeout(WORKSPACE_RESTART_TIMEOUT + 60000);
+
+		const currentWorkspaceName: string = WorkspaceHandlingTests.getWorkspaceName();
+		await workspaces.waitWorkspaceWithStoppedStatus(currentWorkspaceName);
+
+		const originalWindowHandle: string = await browserTabsUtil.getCurrentWindowHandle();
+		await workspaces.clickOpenButton(currentWorkspaceName);
+
+		await browserTabsUtil.waitAndSwitchToAnotherWindow(originalWindowHandle, WORKSPACE_RESTART_TIMEOUT);
+		await driverHelper.wait(TIMEOUT_CONSTANTS.TS_IDE_LOAD_TIMEOUT);
+		await projectAndFileTests.waitWorkspaceReadinessForCheCodeEditor();
+	});
+
+	test('Verify Python execution after workspace restart', async function (): Promise<void> {
+		const projectSection: ViewSection = await projectAndFileTests.getProjectViewSession();
+		await projectSection.openItem(PROJECT_NAME, PYTHON_FILE_NAME);
+		await driverHelper.wait(TIMEOUT_CONSTANTS.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
+
+		await driverHelper.waitAndClick(RUN_PYTHON_BUTTON);
+		await driverHelper.wait(TIMEOUT_CONSTANTS.TS_DIALOG_WINDOW_DEFAULT_TIMEOUT);
+
+		const terminalOutput: string = await driverHelper.waitAndGetText(TERMINAL_OUTPUT, TIMEOUT_CONSTANTS.TS_COMMON_PLUGIN_TEST_TIMEOUT);
+		expect(terminalOutput).to.include('Hello, world!');
+	});
+
+	suiteTeardown('Open dashboard and close all other tabs', async function (): Promise<void> {
+		await dashboard.openDashboard();
+		await browserTabsUtil.closeAllTabsExceptCurrent();
+	});
+
+	suiteTeardown('Stop and delete the workspace by API', async function (): Promise<void> {
+		await testWorkspaceUtil.stopAndDeleteWorkspaceByName(WorkspaceHandlingTests.getWorkspaceName());
+	});
+
+	suiteTeardown('Unregister running workspace', function (): void {
+		registerRunningWorkspace('');
+	});
+});


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
- [U59](https://gitlab.cee.redhat.com/codeready-workspaces/test-cases/-/blob/master/tests/functional/editors/vscode/u59-vs-code-extension-activation-test.md) test case: Automates  extension activation testing
- [CRW-8231](https://issues.redhat.com//browse/CRW-8231): VS Code extension activation issues after page refresh
- [Workspace button selector bug](https://github.com/eclipse-che/che/commit/ee6c12b5d519ffe3156caf3783fa4116d7459969): Fixed consistently failing workspaces.clickOpenButton() method. No existing tests were using the broken button selector, so this fix only benefits future tests.

Test verifies:

1. Workspace creation from https://github.com/crw-qe/python-hello-world/tree/test-vscode-extensions
2. Python file execution produces "Hello, world!" output
3. Extension functionality persists after page refresh
4. Extension functionality persists after workspace restart
5. No activation errors in Python output panel

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
Automates verification of [CRW-8231](https://issues.redhat.com//browse/CRW-8231)
[CRW-9178](https://issues.redhat.com/browse/CRW-9178) 

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
 Successful typescript test runs:

- [ Build #42498: ExtensionActivationTest | OCP 4.19 on ocp419-mszuc.crw-qe.com (Aug 30, 2025, 12:38:16 PM) ](https://jenkins-csb-crwqe-main.dno.corp.redhat.com/job/Testing/job/e2e/job/basic/job/typescript-tests/42498/)
- [ Build #42501: ExtensionActivationTest | OCP 4.18 on ocp418.crw-qe.com (Aug 30, 2025, 12:58:25 PM) ](https://jenkins-csb-crwqe-main.dno.corp.redhat.com/job/Testing/job/e2e/job/basic/job/typescript-tests/42501/)

 
 Test yourself with:
 ```
export USERSTORY=ExtensionActivationTest
export NODE_TLS_REJECT_UNAUTHORIZED=0
export TS_OCP_LOGIN_PAGE_PROVIDER_TITLE=htpasswd
export TS_SELENIUM_VALUE_OPENSHIFT_OAUTH=true
export TS_SELENIUM_HEADLESS=false
export OCP_VERSION=4.19
export TS_SELENIUM_BASE_URL=
export OCP_CONSOLE_URL=
export TS_SELENIUM_OCP_PASSWORD=
export TS_SELENIUM_OCP_USERNAME=

npm run test
```


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
