### PR TITLE
[Test] Fix up 'getProjectNameFromGitUrl' method in 'StringUtils'

### DIFF
--- a/tests/e2e/utils/StringUtil.ts
+++ b/tests/e2e/utils/StringUtil.ts
@@ -30,24 +30,21 @@ export class StringUtil {
 	static getProjectNameFromGitUrl(url: string): string {
 		Logger.debug(`Original URL: ${url}`);
 
-		try {
-			// remove query and hash fragments
-			url = url.split('?')[0].split('#')[0];
+		// remove query and hash fragments
+		url = url.split('?')[0].split('#')[0];
 
-			// remove branch/tree path fragments for major providers
-			url = url
-				.replace(/\/-?\/tree\/[^/]+$/, '') // gitLab, GitHub
-				.replace(/\/src\/[^/]+.*$/, ''); // bitbucket
-
-			// take the last segment of the path and strip ".git"
-			const projectName: string = (url.split('/').filter(Boolean).pop() || '').replace(/\.git$/, '');
-
-			Logger.debug(`Extracted project name: ${projectName}`);
-			return projectName;
-		} catch (err) {
-			Logger.error(`Failed to extract project name from URL ${url}: ${err}`);
-			return '';
+		// remove branch/tree fragments for GitHub, GitLab, Bitbucket
+		if (url.includes('/tree/') || url.includes('/-/tree/') || url.includes('/src/')) {
+			url = url.split('/').slice(0, -2).join('/');
 		}
+
+		const projectName: string = url
+			.split(/[\/.]/)
+			.filter((e: string): boolean => !['git', ''].includes(e))
+			.reverse()[0];
+
+		Logger.debug(`Extracted project name: ${projectName}`);
+		return projectName;
 	}
 
 	static sanitizeTitle(arg: string): string {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
* Fixes `getProjectNameFromGitUr` method to avoid wrong getting name repo from a link like https://github.com/crw-qe/ubi9-based-sample-public/tree/ubi9 

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

Logs from locally run test:
```
      ✔ Wait workspace readiness (38446ms)
          ▼ Function.getProjectNameFromGitUrl - Original URL: https://github.com/crw-qe/ubi9-based-sample-public/tree/ubi9
          ▼ Function.getProjectNameFromGitUrl - Extracted project name: ubi9-based-sample-public
          ▼ ProjectAndFileTests.getProjectViewSession
            ‣ DriverHelper.waitVisibility - By(css selector, .monaco-list-row)
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #2, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ ProjectAndFileTests.getProjectTreeItem - ubi9-based-sample-public
            ‣ DriverHelper.waitVisibility - By(xpath, .//div[@role='treeitem' and @aria-level='2'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
      ✔ Check a project folder has been created
 ```


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
 
- Run usually `SmokeTest` with a link like `https://github.com/crw-qe/ubi9-based-sample-public/tree/ubi9`

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
