### PR TITLE
[Test] Support SSH keys from environment variables in SshUrlNoOauthPatFactory E2E test

### DIFF
--- a/tests/e2e/constants/FACTORY_TEST_CONSTANTS.ts
+++ b/tests/e2e/constants/FACTORY_TEST_CONSTANTS.ts
@@ -27,6 +27,8 @@ export const FACTORY_TEST_CONSTANTS: {
 	TS_SELENIUM_FACTORY_GIT_REPO_BRANCH: string;
 	TS_SELENIUM_SSH_PRIVATE_KEY_PATH: string;
 	TS_SELENIUM_SSH_PUBLIC_KEY_PATH: string;
+	TS_SELENIUM_SSH_PRIVATE_KEY: string;
+	TS_SELENIUM_SSH_PUBLIC_KEY: string;
 	TS_SELENIUM_FACTORY_URL(): string;
 } = {
 	/**
@@ -68,6 +70,16 @@ export const FACTORY_TEST_CONSTANTS: {
 	 * path to SSH public key file
 	 */
 	TS_SELENIUM_SSH_PUBLIC_KEY_PATH: process.env.TS_SELENIUM_SSH_PUBLIC_KEY_PATH || 'resources/factory/pub-k.txt',
+
+	/**
+	 * sSH private key as string (from environment variable)
+	 */
+	TS_SELENIUM_SSH_PRIVATE_KEY: process.env.TS_SELENIUM_SSH_PRIVATE_KEY || '',
+
+	/**
+	 * sSH public key as string (from environment variable)
+	 */
+	TS_SELENIUM_SSH_PUBLIC_KEY: process.env.TS_SELENIUM_SSH_PUBLIC_KEY || '',
 
 	/**
 	 * full factory URL

--- a/tests/e2e/pageobjects/dashboard/UserPreferences.ts
+++ b/tests/e2e/pageobjects/dashboard/UserPreferences.ts
@@ -148,6 +148,33 @@ export class UserPreferences {
 		Logger.info('SSH keys have been added');
 	}
 
+	async addSshKeysFromStrings(privateSshKey: string, publicSshKey: string): Promise<void> {
+		Logger.debug();
+
+		if (!privateSshKey || privateSshKey === '') {
+			throw new Error('Private SSH key is empty or not provided');
+		}
+		if (!publicSshKey || publicSshKey === '') {
+			throw new Error('Public SSH key is empty or not provided');
+		}
+
+		Logger.info('Adding new SSH keys from strings');
+		await this.driverHelper.waitAndClick(UserPreferences.ADD_NEW_SSH_KEY_BUTTON);
+		await this.driverHelper.waitVisibility(UserPreferences.ADD_SSH_KEYS_POPUP);
+
+		Logger.info('Pasting private SSH key');
+		await this.driverHelper.waitAndClick(UserPreferences.PASTE_PRIVATE_SSH_KEY_FIELD);
+		await this.driverHelper.getAction().sendKeys(privateSshKey).perform();
+
+		Logger.info('Pasting public SSH key');
+		await this.driverHelper.waitAndClick(UserPreferences.PASTE_PUBLIC_SSH_KEY_FIELD);
+		await this.driverHelper.getAction().sendKeys(publicSshKey).perform();
+
+		await this.driverHelper.waitAndClick(UserPreferences.ADD_SSH_KEYS_BUTTON);
+		await this.driverHelper.waitVisibility(UserPreferences.GIT_SSH_KEY_NAME);
+		Logger.info('SSH keys have been added');
+	}
+
 	async uploadSshKeys(privateSshKeyPath: string, publicSshKeyPath: string): Promise<void> {
 		Logger.debug();
 		const privateSshKey: string = Buffer.from(fs.readFileSync(path.resolve(privateSshKeyPath), 'utf-8'), 'base64').toString('utf-8');

--- a/tests/e2e/pageobjects/dashboard/UserPreferences.ts
+++ b/tests/e2e/pageobjects/dashboard/UserPreferences.ts
@@ -136,10 +136,10 @@ export class UserPreferences {
 		await this.driverHelper.waitVisibility(UserPreferences.ADD_NEW_SSH_KEY_BUTTON);
 	}
 
-	async addSshKeys(privateSshKeyPath: string, publicSshKeyPath: string): Promise<void> {
+	async addSshKeysFromFiles(privateSshKeyPath: string, publicSshKeyPath: string): Promise<void> {
 		Logger.debug();
 
-		Logger.info('Adding new SSH keys');
+		Logger.info('Adding new SSH keys from files');
 		await this.driverHelper.waitAndClick(UserPreferences.ADD_NEW_SSH_KEY_BUTTON);
 		await this.driverHelper.waitVisibility(UserPreferences.ADD_SSH_KEYS_POPUP);
 		await this.uploadSshKeys(privateSshKeyPath, publicSshKeyPath);

--- a/tests/e2e/specs/factory/SshUrlNoOauthPatFactory.spec.ts
+++ b/tests/e2e/specs/factory/SshUrlNoOauthPatFactory.spec.ts
@@ -65,7 +65,7 @@ suite(`The SshUrlNoOauthPatFactory userstory ${BASE_TEST_CONSTANTS.TEST_ENVIRONM
 				await userPreferences.addSshKeysFromStrings(privateSshKey, publicSshKey);
 			} else {
 				Logger.info('Using SSH keys from file paths');
-				await userPreferences.addSshKeys(privateSshKeyPath, publicSshKeyPath);
+				await userPreferences.addSshKeysFromFiles(privateSshKeyPath, publicSshKeyPath);
 			}
 		});
 		test(`Create and open new workspace from factory:${factoryUrl}`, async function (): Promise<void> {

--- a/tests/e2e/specs/factory/SshUrlNoOauthPatFactory.spec.ts
+++ b/tests/e2e/specs/factory/SshUrlNoOauthPatFactory.spec.ts
@@ -36,6 +36,8 @@ suite(`The SshUrlNoOauthPatFactory userstory ${BASE_TEST_CONSTANTS.TEST_ENVIRONM
 	const factoryUrl: string =
 		FACTORY_TEST_CONSTANTS.TS_SELENIUM_FACTORY_GIT_REPO_URL ||
 		'ssh://git@bitbucket-ssh.apps.ds-airgap2-v15.crw-qe.com/~admin/private-bb-repo.git';
+	const privateSshKey: string = FACTORY_TEST_CONSTANTS.TS_SELENIUM_SSH_PRIVATE_KEY;
+	const publicSshKey: string = FACTORY_TEST_CONSTANTS.TS_SELENIUM_SSH_PUBLIC_KEY;
 	const privateSshKeyPath: string = FACTORY_TEST_CONSTANTS.TS_SELENIUM_SSH_PRIVATE_KEY_PATH;
 	const publicSshKeyPath: string = FACTORY_TEST_CONSTANTS.TS_SELENIUM_SSH_PUBLIC_KEY_PATH;
 	let projectSection: ViewSection;
@@ -57,7 +59,14 @@ suite(`The SshUrlNoOauthPatFactory userstory ${BASE_TEST_CONSTANTS.TEST_ENVIRONM
 		test('Add SSH keys', async function (): Promise<void> {
 			await userPreferences.openUserPreferencesPage();
 			await userPreferences.openSshKeyTab();
-			await userPreferences.addSshKeys(privateSshKeyPath, publicSshKeyPath);
+			// use environment variables if available, otherwise fall back to file paths
+			if (privateSshKey && publicSshKey) {
+				Logger.info('Using SSH keys from environment variables');
+				await userPreferences.addSshKeysFromStrings(privateSshKey, publicSshKey);
+			} else {
+				Logger.info('Using SSH keys from file paths');
+				await userPreferences.addSshKeys(privateSshKeyPath, publicSshKeyPath);
+			}
 		});
 		test(`Create and open new workspace from factory:${factoryUrl}`, async function (): Promise<void> {
 			await workspaceHandlingTests.createAndOpenWorkspaceFromGitRepository(factoryUrl);


### PR DESCRIPTION
### What does this PR do?
Support SSH keys from environment variables in SshUrlNoOauthPatFactory E2E test:
- Added `addSshKeysFromStrings()` method to `UserPreferences` page object for direct SSH key string input
- Added `TS_SELENIUM_SSH_PRIVATE_KEY` and `TS_SELENIUM_SSH_PUBLIC_KEY` constants to `FACTORY_TEST_CONSTANTS`
- Updated `SshUrlNoOauthPatFactory` test to support dual-mode SSH key loading:
  - **Priority 1**: Environment variables (if set)
  - **Priority 2**: File paths (fallback)
- Added input validation for SSH keys with clear error messages

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
This PR is part of https://issues.redhat.com/browse/CRW-5392

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->

To test with environment variables set `TS_SELENIUM_SSH_PRIVATE_KEY` and `TS_SELENIUM_SSH_PUBLIC_KEY`
To test with file paths set `TS_SELENIUM_SSH_PRIVATE_KEY_PATH` and `TS_SELENIUM_SSH_PUBLIC_KEY_PATH`

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
