### PR TITLE
ci : add github `action/stale` to automatically flag and close inactive issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,60 @@
+name: "Lifecycle: Mark and close stale issues"
+
+on:
+  schedule:
+    - cron: "0 2 * * *" # Run every day at 02:00 UTC
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v10
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+          # --- Issue configuration ---
+          stale-issue-label: "lifecycle/stale"
+          exempt-issue-labels: "lifecycle/frozen"
+          remove-issue-stale-when-updated: true
+          days-before-issue-stale: 180
+          days-before-issue-close: 7
+          stale-issue-message: >
+            This issue has been automatically marked as stale due to 180 days of inactivity.
+
+            If this issue is still relevant, please add a comment to keep it open.
+
+            Otherwise, it will be closed after 7 more days of inactivity.
+
+            Moderators: Add the `lifecycle/frozen` label to exempt this issue from the stale process.
+          close-issue-message: >
+            Closing this issue as it remained inactive after being marked `lifecycle/stale`.
+
+          # --- PR configuration ---
+          stale-pr-label: "lifecycle/stale"
+          exempt-pr-labels: "lifecycle/frozen"
+          remove-pr-stale-when-updated: true
+          exempt-draft-pr: false
+          days-before-pr-stale: 180
+          days-before-pr-close: 7
+          stale-pr-message: >
+            This pull request has been automatically marked as stale due to 180 days of inactivity.
+
+            Please update it or comment if you intend to continue working on it.
+
+            It will be closed after 7 more days of inactivity.
+
+            Moderators: Add the `lifecycle/frozen` label to exempt this PR from the stale process.
+          close-pr-message: >
+            Closing this pull request as it remained inactive after being marked `lifecycle/stale`.
+
+          # --- Shared settings ---
+          labels-to-remove-when-unstale: "lifecycle/stale"
+          sort-by: "created"
+          start-date: "2025-11-03T00:24:55Z"
+          operations-per-run: 100


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
This PR is part of DevTools Week.

- Adds a new workflow file:  
  `.github/workflows/stale.yml`
- Uses `actions/stale@v10`
- Schedules daily runs at **02:00 UTC**
- Automatically handles stale labeling, commenting, and closing issues and pull requests

It aims to replace the outdated repository https://github.com/che-incubator/chestnut-lite which is not working since January (see [Chestnut](https://github.com/che-incubator/chestnut-lite) [actions page](https://github.com/che-incubator/chestnut-lite/actions?page=5)). Here a few benefits of using GitHub Actions instead of our own solution:
- Eliminates custom TypeScript code and maintenance overhead
- Fully supported by GitHub Actions
- Provides predictable, consistent stale management
- Easier to configure and update via YAML instead of code



#### Behavior

- Marks issues/PRs as stale after **180 days of inactivity**
- Closes issues **7 days** after being marked stale
- Stale issues/PRs are labeled `lifecycle/stale`
- Issues/PRs with the label `lifecycle/frozen` are exempt
- Comment messages guide users on how to mark the issue/PRs as active
- Automatically removes the stale label if activity resumes 
- Limits operations to **100 issues per run** (can be adjusted as per needs)

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
This workflow is supposed to run as a GitHub action every night and post comments on issues that are inactive since some time:

<img width="947" height="288" alt="Screenshot 2025-11-05 at 16 28 52" src="https://github.com/user-attachments/assets/0b624757-dd9e-454a-a057-214618434a0f" />

If even after marking issue/PR stale there is no activity. Issue is closed:

<img width="948" height="208" alt="Screenshot 2025-11-07 at 15 05 21" src="https://github.com/user-attachments/assets/f4fb566f-5d32-47ad-b861-b2ed60643d3e" />


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
This issue is part of https://github.com/eclipse-che/che/issues/23627
> Replace [https://github.com/che-incubator/chestnut-lite](https://github.com/che-incubator/chestnut-lite/actions/workflows/check.yml) with [actions/stale](https://github.com/actions/stale)

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
I've tested it on a personal repo. 

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
