### PR TITLE
[Test] Fix up 'StringUtils' and 'SmokeTest' 

### DIFF
--- a/tests/e2e/specs/SmokeTest.spec.ts
+++ b/tests/e2e/specs/SmokeTest.spec.ts
@@ -27,7 +27,7 @@ suite(`The SmokeTest userstory ${BASE_TEST_CONSTANTS.TEST_ENVIRONMENT}`, functio
 	const browserTabsUtil: BrowserTabsUtil = e2eContainer.get(CLASSES.BrowserTabsUtil);
 	const factoryUrl: string =
 		FACTORY_TEST_CONSTANTS.TS_SELENIUM_FACTORY_GIT_REPO_URL ||
-		'https://github.com/che-incubator/quarkus-api-example.git?policies.create=perclick';
+		'https://github.com/che-incubator/quarkus-api-example.git?new';
 	let projectSection: ViewSection;
 	suite(`Create workspace from factory:${factoryUrl}`, function (): void {
 		suiteSetup('Login', async function (): Promise<void> {

--- a/tests/e2e/specs/SmokeTest.spec.ts
+++ b/tests/e2e/specs/SmokeTest.spec.ts
@@ -26,8 +26,7 @@ suite(`The SmokeTest userstory ${BASE_TEST_CONSTANTS.TEST_ENVIRONMENT}`, functio
 	const loginTests: LoginTests = e2eContainer.get(CLASSES.LoginTests);
 	const browserTabsUtil: BrowserTabsUtil = e2eContainer.get(CLASSES.BrowserTabsUtil);
 	const factoryUrl: string =
-		FACTORY_TEST_CONSTANTS.TS_SELENIUM_FACTORY_GIT_REPO_URL ||
-		'https://github.com/che-incubator/quarkus-api-example.git?new';
+		FACTORY_TEST_CONSTANTS.TS_SELENIUM_FACTORY_GIT_REPO_URL || 'https://github.com/che-incubator/quarkus-api-example.git?new';
 	let projectSection: ViewSection;
 	suite(`Create workspace from factory:${factoryUrl}`, function (): void {
 		suiteSetup('Login', async function (): Promise<void> {

--- a/tests/e2e/utils/StringUtil.ts
+++ b/tests/e2e/utils/StringUtil.ts
@@ -34,8 +34,15 @@ export class StringUtil {
 		url = url.split('?')[0].split('#')[0];
 
 		// remove branch/tree fragments for GitHub, GitLab, Bitbucket
-		if (url.includes('/tree/') || url.includes('/-/tree/') || url.includes('/src/')) {
-			url = url.split('/').slice(0, -2).join('/');
+		if (url.includes('/-/tree/')) {
+			// gitLab specific pattern: remove everything from /-/tree/ onwards
+			url = url.substring(0, url.indexOf('/-/tree/'));
+		} else if (url.includes('/tree/')) {
+			// gitHub pattern: remove /tree/ and everything after it
+			url = url.substring(0, url.indexOf('/tree/'));
+		} else if (url.includes('/src/')) {
+			// bitbucket pattern: remove /src/ and everything after it
+			url = url.substring(0, url.indexOf('/src/'));
 		}
 
 		const projectName: string = url


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
* Fixed up `SmokeTest` E2E test by replacing `policies.create=perclick` on `new` query parameter according new behavior
* Fixed up `getProjectNameFromGitUrl` method in `StringUtils` to avoid an error of getting project name:
```
11:07:29            ▼ Function.getProjectNameFromGitUrl - Original URL: https://gitlab-gitlab-system.apps.git.crw-qe.com/test-user/private-gitlab-repo.git/-/tree/refreshToken?new
11:07:29            ▼ Function.getProjectNameFromGitUrl - Extracted project name: -
.....
11:07:33      1) Check if a project folder has been created
11:07:33    [ERROR] CheReporter runner.on.fail: Create a workspace via launching a factory from the gitlab repository  Check if a project folder has been created failed after 3681ms
```

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
* Run `SmokeTest` as usually
* To check `getProjectNameFromGitUrl`:
**-- create `test-string-util.js` temporary file in `e2e` folder:**
```
// Temporary test to check the getProjectNameFromGitUrl method
class MockLogger {
    static debug(msg) {
        console.log(`[DEBUG] ${msg}`);
    }
}

// Copy a logic
function getProjectNameFromGitUrl(url) {
    MockLogger.debug(`Original URL: ${url}`);

    // remove query and hash fragments
    url = url.split('?')[0].split('#')[0];

    // remove branch/tree fragments for GitHub, GitLab, Bitbucket
    if (url.includes('/-/tree/')) {
        // GitLab specific pattern: remove everything from /-/tree/ onwards
        url = url.substring(0, url.indexOf('/-/tree/'));
    } else if (url.includes('/tree/')) {
        // GitHub pattern: remove /tree/ and everything after it
        url = url.substring(0, url.indexOf('/tree/'));
    } else if (url.includes('/src/')) {
        // Bitbucket pattern: remove /src/ and everything after it
        url = url.substring(0, url.indexOf('/src/'));
    }

    const projectName = url
        .split(/[\/.]/)
        .filter((e) => !['git', ''].includes(e))
        .reverse()[0];

    MockLogger.debug(`Extracted project name: ${projectName}`);
    return projectName;
}

// Test cases
const testCases = [
    {
        url: 'https://gitlab-gitlab-system.apps.git.crw-qe.com/test-user/private-gitlab-repo.git/-/tree/refreshToken?new',
        expected: 'private-gitlab-repo',
        description: 'GitLab URL with branch and query parameters'
    },
    {
        url: 'https://github.com/crw-qe/ubi9-based-sample-public/tree/ubi9',
        expected: 'ubi9-based-sample-public',
        description: 'GitHub URL with branch'
    },
    {
        url: 'https://github.com/che-incubator/quarkus-api-example.git?new',
        expected: 'quarkus-api-example',
        description: 'GitHub URL with query parameters'
    },
    {
        url: 'https://gitlab.com/user/repo.git/-/tree/branch',
        expected: 'repo',
        description: 'GitLab URL with branch'
    },
    {
        url: 'https://github.com/user/repo.git',
        expected: 'repo',
        description: 'Simple GitHub URL'
    },
    {
        url: 'https://github.com/user/repo.git/tree/main',
        expected: 'repo',
        description: 'GitHub URL with branch'
    },
    {
        url: 'https://username@bitbucket.org/username/repo.git',
        expected: 'repo',
        description: 'Bitbucket URL with username'
    },
    {
        url: 'https://bitbucket.org/user/repo.git/src/main',
        expected: 'repo',
        description: 'Bitbucket URL with branch'
    },
    {
        url: 'ssh://git@bitbucket-ssh.apps.ds-airgap2-v15.crw-qe.com/~admin/repo.git',
        expected: 'repo',
        description: 'Bitbucket SSH URL'
    }
];

console.log('=== Тesting method getProjectNameFromGitUrl ===\n');

let passed = 0;
let failed = 0;

testCases.forEach((testCase, index) => {
    console.log(`\nТест ${index + 1}: ${testCase.description}`);
    console.log(`URL: ${testCase.url}`);
    
    const result = getProjectNameFromGitUrl(testCase.url);
    
    console.log(`Expected: '${testCase.expected}'`);
    console.log(`Got: '${result}'`);
    
    if (result === testCase.expected) {
        console.log(`✅ PASSED`);
        passed++;
    } else {
        console.log(`❌ FAILED`);
        failed++;
    }
    console.log('---');
});

console.log(`\n=== Results ===`);
console.log(`✅ PASSED tests: ${passed}`);
console.log(`❌ FAILED tests: ${failed}`);
console.log(`Total tests: ${passed + failed}`);
```
**-- run it by command `node test-string-util.js` , see results:**
```
[ashmaraiev@fedora e2e]$ node test-string-util.js 
=== Тesting method getProjectNameFromGitUrl ===


Тест 1: GitLab URL with branch and query parameters
URL: https://gitlab-gitlab-system.apps.git.crw-qe.com/test-user/private-gitlab-repo.git/-/tree/refreshToken?new
[DEBUG] Original URL: https://gitlab-gitlab-system.apps.git.crw-qe.com/test-user/private-gitlab-repo.git/-/tree/refreshToken?new
[DEBUG] Extracted project name: private-gitlab-repo
Expected: 'private-gitlab-repo'
Got: 'private-gitlab-repo'
✅ PASSED
---

Тест 2: GitHub URL with branch
URL: https://github.com/crw-qe/ubi9-based-sample-public/tree/ubi9
[DEBUG] Original URL: https://github.com/crw-qe/ubi9-based-sample-public/tree/ubi9
[DEBUG] Extracted project name: ubi9-based-sample-public
Expected: 'ubi9-based-sample-public'
Got: 'ubi9-based-sample-public'
✅ PASSED
---

Тест 3: GitHub URL with query parameters
URL: https://github.com/che-incubator/quarkus-api-example.git?new
[DEBUG] Original URL: https://github.com/che-incubator/quarkus-api-example.git?new
[DEBUG] Extracted project name: quarkus-api-example
Expected: 'quarkus-api-example'
Got: 'quarkus-api-example'
✅ PASSED
---

Тест 4: GitLab URL with branch
URL: https://gitlab.com/user/repo.git/-/tree/branch
[DEBUG] Original URL: https://gitlab.com/user/repo.git/-/tree/branch
[DEBUG] Extracted project name: repo
Expected: 'repo'
Got: 'repo'
✅ PASSED
---

Тест 5: Simple GitHub URL
URL: https://github.com/user/repo.git
[DEBUG] Original URL: https://github.com/user/repo.git
[DEBUG] Extracted project name: repo
Expected: 'repo'
Got: 'repo'
✅ PASSED
---

Тест 6: GitHub URL with branch
URL: https://github.com/user/repo.git/tree/main
[DEBUG] Original URL: https://github.com/user/repo.git/tree/main
[DEBUG] Extracted project name: repo
Expected: 'repo'
Got: 'repo'
✅ PASSED
---

Тест 7: Bitbucket URL with username
URL: https://username@bitbucket.org/username/repo.git
[DEBUG] Original URL: https://username@bitbucket.org/username/repo.git
[DEBUG] Extracted project name: repo
Expected: 'repo'
Got: 'repo'
✅ PASSED
---

Тест 8: Bitbucket URL with branch
URL: https://bitbucket.org/user/repo.git/src/main
[DEBUG] Original URL: https://bitbucket.org/user/repo.git/src/main
[DEBUG] Extracted project name: repo
Expected: 'repo'
Got: 'repo'
✅ PASSED
---

Тест 9: Bitbucket SSH URL
URL: ssh://git@bitbucket-ssh.apps.ds-airgap2-v15.crw-qe.com/~admin/repo.git
[DEBUG] Original URL: ssh://git@bitbucket-ssh.apps.ds-airgap2-v15.crw-qe.com/~admin/repo.git
[DEBUG] Extracted project name: repo
Expected: 'repo'
Got: 'repo'
✅ PASSED
---

=== Results ===
✅ PASSED tests: 9
❌ FAILED tests: 0
Total tests: 9
```



### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
