### PR TITLE
[Test] Fix setupGitConfig to handle already configured git credentials

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -42,8 +42,8 @@ jobs:
           echo running on PR ${GITHUB_REF}, branch - ${GITHUB_HEAD_REF}
           echo "pr_number=$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')" >> "$GITHUB_ENV"
           docker images
-          # remove build-in images form the VM becqause it is not used
-          docker rmi -f $(docker images -aq)
+          # remove build-in images from the VM because it is not used
+          docker rmi -f $(docker images -aq) || true
 
       - name: Configuring nodejs 18.x version
         uses: actions/setup-node@v3

--- a/tests/e2e/pageobjects/dashboard/UserPreferences.ts
+++ b/tests/e2e/pageobjects/dashboard/UserPreferences.ts
@@ -152,15 +152,15 @@ export class UserPreferences {
 		);
 	}
 
-	async setupGitConfig(userName: string, userEmail: string): Promise<void> {
+	async ensureGitConfig(userName: string, userEmail: string): Promise<void> {
 		await this.openUserPreferencesPage();
 		await this.openGitConfigPage();
 
 		// check if the values are already set correctly
-		const currentName: string = await this.driverHelper.waitAndGetElementAttribute(UserPreferences.GIT_CONFIG_USER_NAME, 'value');
+		const currentUserName: string = await this.driverHelper.waitAndGetElementAttribute(UserPreferences.GIT_CONFIG_USER_NAME, 'value');
 		const currentEmail: string = await this.driverHelper.waitAndGetElementAttribute(UserPreferences.GIT_CONFIG_USER_EMAIL, 'value');
 
-		if (currentName === userName && currentEmail === userEmail) {
+		if (currentUserName === userName && currentEmail === userEmail) {
 			Logger.info(`Git config already set correctly: name="${userName}", email="${userEmail}"`);
 			return;
 		}

--- a/tests/e2e/pageobjects/dashboard/UserPreferences.ts
+++ b/tests/e2e/pageobjects/dashboard/UserPreferences.ts
@@ -155,9 +155,20 @@ export class UserPreferences {
 	async setupGitConfig(userName: string, userEmail: string): Promise<void> {
 		await this.openUserPreferencesPage();
 		await this.openGitConfigPage();
+
+		// check if the values are already set correctly
+		const currentName: string = await this.driverHelper.waitAndGetElementAttribute(UserPreferences.GIT_CONFIG_USER_NAME, 'value');
+		const currentEmail: string = await this.driverHelper.waitAndGetElementAttribute(UserPreferences.GIT_CONFIG_USER_EMAIL, 'value');
+
+		if (currentName === userName && currentEmail === userEmail) {
+			Logger.info(`Git config already set correctly: name="${userName}", email="${userEmail}"`);
+			return;
+		}
+
+		Logger.info(`Setting git config: name="${userName}", email="${userEmail}"`);
 		await this.enterGitConfigUsernameAndEmail(userName, userEmail);
 		await this.clickOnGitConfigSaveButton();
-		// await userPreferences.waitGitConfigSaveButtonIsDisabled();// TODO: restore line after fix https://github.com/eclipse-che/che/issues/23625
+		await this.waitGitConfigSaveButtonIsDisabled();
 	}
 
 	async openSshKeyTab(): Promise<void> {

--- a/tests/e2e/specs/factory/NoSetupRepoFactory.spec.ts
+++ b/tests/e2e/specs/factory/NoSetupRepoFactory.spec.ts
@@ -78,7 +78,7 @@ suite(
 
 		suiteSetup('Login', async function (): Promise<void> {
 			await loginTests.loginIntoChe();
-			await userPreferences.setupGitConfig(
+			await userPreferences.ensureGitConfig(
 				FACTORY_TEST_CONSTANTS.TS_GIT_COMMIT_AUTHOR_NAME,
 				FACTORY_TEST_CONSTANTS.TS_GIT_COMMIT_AUTHOR_EMAIL
 			);

--- a/tests/e2e/specs/factory/RefusedOAuthFactory.spec.ts
+++ b/tests/e2e/specs/factory/RefusedOAuthFactory.spec.ts
@@ -220,7 +220,7 @@ suite(
 				await dashboard.stopWorkspaceByUI(currentWorkspaceName);
 				await workspaces.waitWorkspaceWithStoppedStatus(currentWorkspaceName);
 
-				await userPreferences.setupGitConfig(
+				await userPreferences.ensureGitConfig(
 					FACTORY_TEST_CONSTANTS.TS_GIT_COMMIT_AUTHOR_NAME,
 					FACTORY_TEST_CONSTANTS.TS_GIT_COMMIT_AUTHOR_EMAIL
 				);

--- a/tests/e2e/specs/factory/SshUrlNoOauthPatFactory.spec.ts
+++ b/tests/e2e/specs/factory/SshUrlNoOauthPatFactory.spec.ts
@@ -76,7 +76,7 @@ suite(`The SshUrlNoOauthPatFactory userstory ${BASE_TEST_CONSTANTS.TEST_ENVIRONM
 	suite(`Create workspace from factory:${factoryUrl}`, function (): void {
 		suiteSetup('Login', async function (): Promise<void> {
 			await loginTests.loginIntoChe();
-			await userPreferences.setupGitConfig(
+			await userPreferences.ensureGitConfig(
 				FACTORY_TEST_CONSTANTS.TS_GIT_COMMIT_AUTHOR_NAME,
 				FACTORY_TEST_CONSTANTS.TS_GIT_COMMIT_AUTHOR_EMAIL
 			);


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?

The `setupGitConfig` method in `UserPreferences.ts` was failing when the git config (username and email) was already set to the same values that the test was trying to configure.
When the fields already contain the correct values:
1. Entering the same data doesn't trigger any change
2. The `Save` button remains disabled (no changes detected)
3. `clickOnGitConfigSaveButton()` fails because the button is not active



### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-9948

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
