### PR TITLE
PredefinedNamespace test should use the latest Dev Spaces VS Code Editor image

### DIFF
--- a/tests/e2e/specs/miscellaneous/PredefinedNamespace.spec.ts
+++ b/tests/e2e/specs/miscellaneous/PredefinedNamespace.spec.ts
@@ -54,21 +54,24 @@ suite(`Create predefined workspace and check it ${BASE_TEST_CONSTANTS.TEST_ENVIR
 	// generate empty workspace DevFile and create it through oc client under a regular user
 	suiteSetup('Login', async function (): Promise<void> {
 		const devfileContent: string = 'schemaVersion: 2.2.0\n' + 'metadata:\n' + `  name: ${workspaceName}\n`;
-		const devSpacesEditorImage: string = 'quay.io/redhat-user-workloads/devspaces-tenant/devspaces/code-rhel9:latest';
+		const majorMinorVersion: string = BASE_TEST_CONSTANTS.TESTING_APPLICATION_VERSION.split('.').slice(0, 2).join('.');
+		const devSpacesEditorImage: string = `quay.io/redhat-user-workloads/devspaces-tenant/devspaces/code-rhel9:${majorMinorVersion}`;
 		kubernetesCommandLineToolsExecutor.loginToOcp(userName);
 		devWorkspaceConfigurationHelper = new DevWorkspaceConfigurationHelper({
 			devfileContent
 		});
 		devfileContext = await devWorkspaceConfigurationHelper.generateDevfileContext();
 
-		// update che-code-injector image to use Dev Spaces VS Code Editor
-		devfileContext.devWorkspaceTemplates.forEach((template): void => {
-			template.spec?.components?.forEach((component): void => {
-				if (component.name === 'che-code-injector' && component.container?.image) {
-					component.container.image = devSpacesEditorImage;
-				}
+		// update che-code-injector image to use Dev Spaces VS Code Editor (Dev Spaces only)
+		if (BASE_TEST_CONSTANTS.TESTING_APPLICATION_NAME() === 'devspaces') {
+			devfileContext.devWorkspaceTemplates.forEach((template): void => {
+				template.spec?.components?.forEach((component): void => {
+					if (component.name === 'che-code-injector' && component.container?.image) {
+						component.container.image = devSpacesEditorImage;
+					}
+				});
 			});
-		});
+		}
 
 		const devWorkspaceConfigurationYamlString: string =
 			devWorkspaceConfigurationHelper.getDevWorkspaceConfigurationYamlAsString(devfileContext);


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
PredefinedNamespace test should use the latest Dev Spaces VS Code Editor image

Update the test to override the che-code-injector container image after the devfile context is generated. The image is now set to the Dev Spaces VS Code Editor:
quay.io/redhat-user-workloads/devspaces-tenant/devspaces/code-rhel9:latest

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-10045

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->

**DevWorkspace** template example after che-code image updation.

```
oc apply -f - 
          apiVersion: workspace.devfile.io/v1alpha2
          kind: DevWorkspaceTemplate
          metadata:
            name: che-code-empty-ws
          spec:
            commands:
              - id: init-container-command
                apply:
                  component: che-code-injector
              - id: init-che-code-command
                exec:
                  component: che-code-runtime-description
                  commandLine: nohup /checode/entrypoint-volume.sh > /checode/entrypoint-logs.txt
                    2>&1 &
            events:
              preStart:
                - init-container-command
              postStart:
                - init-che-code-command
            components:
              - name: che-code-injector
                container:
                  image: quay.io/redhat-user-workloads/devspaces-tenant/devspaces/code-rhel9:3.26
                  command:
                    - /entrypoint-init-container.sh
                  volumeMounts:
                    - name: checode
                      path: /checode
                  memoryLimit: 256Mi
                  memoryRequest: 32Mi
                  cpuLimit: 500m
                  cpuRequest: 30m
              - name: che-code-runtime-description
                container:
                  image: quay.io/devfile/universal-developer-image@sha256:42c94b19f0e3a7cb47d4583f8dd5b3dc77f15d80e0562309a3d2d5145aebfe7a
                  memoryLimit: 1024Mi
                  memoryRequest: 256Mi
                  cpuLimit: 500m
                  cpuRequest: 30m
                  volumeMounts:
                    - name: checode
                      path: /checode
                  endpoints:
                    - name: che-code
                      attributes:
                        type: main
                        cookiesAuthEnabled: true
                        discoverable: false
                        urlRewriteSupported: true
                      targetPort: 3100
                      exposure: public
                      secure: true
                      protocol: https
                    - name: code-redirect-1
                      targetPort: 13131
                      exposure: public
                      protocol: https
                      attributes:
                        discoverable: false
                        urlRewriteSupported: false
                    - name: code-redirect-2
                      targetPort: 13132
                      exposure: public
                      protocol: https
                      attributes:
                        discoverable: false
                        urlRewriteSupported: false
                    - name: code-redirect-3
                      targetPort: 13133
                      exposure: public
                      protocol: https
                      attributes:
                        discoverable: false
                        urlRewriteSupported: false
                attributes:
                  app.kubernetes.io/component: che-code-runtime
                  app.kubernetes.io/part-of: che-code.eclipse.org
                  controller.devfile.io/container-contribution: true
              - name: checode
                volume: {}
          ---
          apiVersion: workspace.devfile.io/v1alpha2
          kind: DevWorkspace
          metadata:
            name: empty-ws
            annotations:
              che.eclipse.org/devfile: |
                schemaVersion: 2.2.0
                metadata:
                  name: empty-ws
          spec:
            started: true
            routingClass: che
            template:
              attributes:
                controller.devfile.io/devworkspace-config:
                  name: devworkspace-config
                  namespace: openshift-devspaces
                controller.devfile.io/scc: container-build
                controller.devfile.io/storage-type: per-user
            contributions:
              - name: editor
                kubernetes:
                  name: che-code-empty-ws
```

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
