### PR TITLE
Add SSH key field validation in UserPreferences to ensure keys are correctly entered

### DIFF
--- a/tests/e2e/pageobjects/dashboard/UserPreferences.ts
+++ b/tests/e2e/pageobjects/dashboard/UserPreferences.ts
@@ -214,9 +214,29 @@ export class UserPreferences {
 		await this.driverHelper.waitAndClick(UserPreferences.PASTE_PRIVATE_SSH_KEY_FIELD);
 		await this.driverHelper.getAction().sendKeys(privateSshKey).perform();
 
+		// verify private SSH key was correctly set
+		const enteredPrivateKey: string = await this.driverHelper.waitAndGetValue(
+			UserPreferences.PASTE_PRIVATE_SSH_KEY_FIELD,
+			TIMEOUT_CONSTANTS.TS_COMMON_DASHBOARD_WAIT_TIMEOUT
+		);
+		if (enteredPrivateKey !== privateSshKey) {
+			throw new Error('Private SSH key was not correctly set in the field');
+		}
+		Logger.info('Private SSH key verified successfully');
+
 		Logger.info('Pasting public SSH key');
 		await this.driverHelper.waitAndClick(UserPreferences.PASTE_PUBLIC_SSH_KEY_FIELD);
 		await this.driverHelper.getAction().sendKeys(publicSshKey).perform();
+
+		// verify public SSH key was correctly set
+		const enteredPublicKey: string = await this.driverHelper.waitAndGetValue(
+			UserPreferences.PASTE_PUBLIC_SSH_KEY_FIELD,
+			TIMEOUT_CONSTANTS.TS_COMMON_DASHBOARD_WAIT_TIMEOUT
+		);
+		if (enteredPublicKey !== publicSshKey) {
+			throw new Error('Public SSH key was not correctly set in the field');
+		}
+		Logger.info('Public SSH key verified successfully');
 
 		if (passphrase) {
 			Logger.info('Pasting SSH key passphrase');


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
When adding SSH keys via **addSshKeysFromStrings** method in **UserPreferences**.ts, there was no verification that the keys were actually entered correctly into the form fields. This could lead to silent failures where the keys appeared to be added but were actually incomplete or corrupted.

Solution
Added validation after pasting each SSH key to verify the field values match the expected input.
If validation fails, an error is thrown with a descriptive message. On success, a confirmation log message is written.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-10117

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
