### PR TITLE
Add verification that files are opened in the editor after clicking in project tree

### DIFF
--- a/tests/e2e/specs/miscellaneous/ExtensionActivationTest.spec.ts
+++ b/tests/e2e/specs/miscellaneous/ExtensionActivationTest.spec.ts
@@ -75,8 +75,7 @@ suite(`Extension Activation Test ${BASE_TEST_CONSTANTS.TEST_ENVIRONMENT}`, funct
 
 	test('Open Python file and run it', async function (): Promise<void> {
 		const projectSection: ViewSection = await projectAndFileTests.getProjectViewSession();
-		await projectSection.openItem(PROJECT_NAME, PYTHON_FILE_NAME);
-		await driverHelper.wait(TIMEOUT_CONSTANTS.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
+		await projectAndFileTests.openFileAndVerify(projectSection, PROJECT_NAME, PYTHON_FILE_NAME);
 
 		await driverHelper.waitAndClick(RUN_PYTHON_BUTTON);
 		await driverHelper.wait(TIMEOUT_CONSTANTS.TS_DIALOG_WINDOW_DEFAULT_TIMEOUT);
@@ -108,8 +107,7 @@ suite(`Extension Activation Test ${BASE_TEST_CONSTANTS.TEST_ENVIRONMENT}`, funct
 		await driverHelper.wait(TIMEOUT_CONSTANTS.TS_IDE_LOAD_TIMEOUT);
 
 		const projectSection: ViewSection = await projectAndFileTests.getProjectViewSession();
-		await projectSection.openItem(PROJECT_NAME, PYTHON_FILE_NAME);
-		await driverHelper.wait(TIMEOUT_CONSTANTS.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
+		await projectAndFileTests.openFileAndVerify(projectSection, PROJECT_NAME, PYTHON_FILE_NAME);
 
 		await driverHelper.waitAndClick(RUN_PYTHON_BUTTON);
 		await driverHelper.wait(TIMEOUT_CONSTANTS.TS_DIALOG_WINDOW_DEFAULT_TIMEOUT);
@@ -147,8 +145,7 @@ suite(`Extension Activation Test ${BASE_TEST_CONSTANTS.TEST_ENVIRONMENT}`, funct
 
 	test('Verify Python execution after workspace restart', async function (): Promise<void> {
 		const projectSection: ViewSection = await projectAndFileTests.getProjectViewSession();
-		await projectSection.openItem(PROJECT_NAME, PYTHON_FILE_NAME);
-		await driverHelper.wait(TIMEOUT_CONSTANTS.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
+		await projectAndFileTests.openFileAndVerify(projectSection, PROJECT_NAME, PYTHON_FILE_NAME);
 
 		await driverHelper.waitAndClick(RUN_PYTHON_BUTTON);
 		await driverHelper.wait(TIMEOUT_CONSTANTS.TS_DIALOG_WINDOW_DEFAULT_TIMEOUT);


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
When clicking on a file in the **Project Explorer** to open it, sometimes the file doesn't actually open in the Editor - especially after closing the Trust Author dialog. Tests would proceed without verifying the file was opened, leading to failures in subsequent steps that depend on the file being open.

**Solution**
Added openFileAndVerify() method to ProjectAndFileTests.ts that:
- Opens a file using projectSection.openItem()
- Verifies the file appears in the editor tabs using EditorView.getOpenEditorTitles()
- Retries up to 2 times if the file doesn't open on the first attempt
- Throws a descriptive error if all attempts fail

**Benefits**

- Ensures file is actually opened before proceeding with test actions
- Provides retry mechanism for flaky file opening after dialogs
- Reusable method available for other tests that need to open files

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-10220

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
