### PR TITLE
Improve Create New checkbox handling in CreateWorkspace page object

### DIFF
--- a/tests/e2e/pageobjects/dashboard/CreateWorkspace.ts
+++ b/tests/e2e/pageobjects/dashboard/CreateWorkspace.ts
@@ -134,10 +134,32 @@ export class CreateWorkspace {
 		return await element.isSelected();
 	}
 
+	async waitForCheckboxState(
+		expectedState: boolean,
+		timeout: number = TIMEOUT_CONSTANTS.TS_COMMON_DASHBOARD_WAIT_TIMEOUT
+	): Promise<void> {
+		Logger.debug(`waiting for checkbox to be ${expectedState ? 'checked' : 'unchecked'}`);
+
+		const polling: number = 500;
+		const attempts: number = Math.ceil(timeout / polling);
+
+		for (let i: number = 0; i < attempts; i++) {
+			const currentState: boolean = await this.isCreateNewWorkspaceCheckboxChecked();
+			if (currentState === expectedState) {
+				Logger.debug(`Checkbox reached expected state: ${expectedState}`);
+				await this.driverHelper.wait(polling);
+				return;
+			}
+			await this.driverHelper.wait(timeout);
+		}
+
+		throw new Error(`Checkbox did not reach expected state ${expectedState} within ${timeout}ms`);
+	}
+
 	async clickOnCreateNewWorkspaceCheckbox(timeout: number = TIMEOUT_CONSTANTS.TS_SELENIUM_WAIT_FOR_URL): Promise<void> {
 		Logger.debug();
 
-		await this.driverHelper.waitAndClick(CreateWorkspace.CREATE_NEW_WORKPACE_CHECKBOX, timeout);
+		await this.driverHelper.scrollToAndClick(CreateWorkspace.CREATE_NEW_WORKPACE_CHECKBOX, timeout);
 	}
 
 	async setCreateNewWorkspaceCheckbox(
@@ -157,8 +179,7 @@ export class CreateWorkspace {
 
 		// click to change state
 		Logger.debug(`Checkbox is ${isCurrentlyChecked ? 'set' : 'unset'}, ${checked ? 'setting' : 'unsetting'} it now`);
-		await this.driverHelper.waitAndClick(CreateWorkspace.CREATE_NEW_WORKPACE_CHECKBOX, timeout);
-		await this.driverHelper.wait(1000);
+		await this.driverHelper.scrollToAndClick(CreateWorkspace.CREATE_NEW_WORKPACE_CHECKBOX, timeout);
 	}
 
 	private getEditorsDropdownListLocator(sampleName: string): By {

--- a/tests/e2e/pageobjects/dashboard/CreateWorkspace.ts
+++ b/tests/e2e/pageobjects/dashboard/CreateWorkspace.ts
@@ -147,10 +147,9 @@ export class CreateWorkspace {
 			const currentState: boolean = await this.isCreateNewWorkspaceCheckboxChecked();
 			if (currentState === expectedState) {
 				Logger.debug(`Checkbox reached expected state: ${expectedState}`);
-				await this.driverHelper.wait(polling);
 				return;
 			}
-			await this.driverHelper.wait(timeout);
+			await this.driverHelper.wait(polling);
 		}
 
 		throw new Error(`Checkbox did not reach expected state ${expectedState} within ${timeout}ms`);

--- a/tests/e2e/pageobjects/dashboard/CreateWorkspace.ts
+++ b/tests/e2e/pageobjects/dashboard/CreateWorkspace.ts
@@ -1,5 +1,5 @@
 /** *******************************************************************
- * copyright (c) 2019-2023 Red Hat, Inc.
+ * copyright (c) 2019-2026 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/tests/e2e/specs/miscellaneous/CreateWorkspaceWithExistingNameFromGitUrl.spec.ts
+++ b/tests/e2e/specs/miscellaneous/CreateWorkspaceWithExistingNameFromGitUrl.spec.ts
@@ -75,7 +75,7 @@ suite(`"Start workspace with existed workspace name" test ${BASE_TEST_CONSTANTS.
 		await waitDashboardPage();
 
 		await createWorkspace.setGitRepositoryUrl(factoryUrl);
-		expect(await createWorkspace.isCreateNewWorkspaceCheckboxChecked()).to.be.false;
+		await createWorkspace.waitForCheckboxState(false);
 		expect(await createWorkspace.getGitRepositoryUrl()).to.be.equal(factoryUrl);
 		await createWorkspace.clickOnCreateAndOpenButton();
 		await createWorkspace.performTrustAuthorPopup();
@@ -102,7 +102,9 @@ suite(`"Start workspace with existed workspace name" test ${BASE_TEST_CONSTANTS.
 		await waitDashboardPage();
 
 		await createWorkspace.setGitRepositoryUrl(factoryUrl);
+		await createWorkspace.waitForCheckboxState(false);
 		await createWorkspace.setCreateNewWorkspaceCheckbox(true);
+		await createWorkspace.waitForCheckboxState(true);
 
 		expect(await createWorkspace.getGitRepositoryUrl()).to.be.equal(factoryUrl + '?new');
 

--- a/tests/e2e/specs/miscellaneous/CreateWorkspaceWithExistingNameFromGitUrl.spec.ts
+++ b/tests/e2e/specs/miscellaneous/CreateWorkspaceWithExistingNameFromGitUrl.spec.ts
@@ -1,5 +1,5 @@
 /** *******************************************************************
- * copyright (c) 2020-2025 Red Hat, Inc.
+ * copyright (c) 2020-2026 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
The "Create New" checkbox in the CreateWorkspace page had several reliability issues:

1. **Checkbox not visible:** The checkbox is located at the bottom of the page and sometimes not visible, causing click failures
2. **State change timing:** When entering a Git repository URL, the checkbox automatically changes state, but this takes variable time

**Solution**

- Added waitForCheckboxState() method - polls every 500ms until checkbox reaches expected state (checked/unchecked), with configurable timeout
- Added scroll before click - both clickOnCreateNewWorkspaceCheckbox() and setCreateNewWorkspaceCheckbox() now use scrollToAndClick() to ensure the checkbox is visible before clicking
- Used polling in setCreateNewWorkspaceCheckbox() - after clicking, waits for checkbox to reach the expected state using the new polling method

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-10403

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
