### PR TITLE
Update Empty Workspace sample test per test-case scenario and add workaround

### DIFF
--- a/tests/e2e/specs/miscellaneous/CreateWorkspaceWithExistingNameFromEmptyWorkspaceSample.spec.ts
+++ b/tests/e2e/specs/miscellaneous/CreateWorkspaceWithExistingNameFromEmptyWorkspaceSample.spec.ts
@@ -20,7 +20,6 @@ import { BASE_TEST_CONSTANTS } from '../../constants/BASE_TEST_CONSTANTS';
 import { Dashboard } from '../../pageobjects/dashboard/Dashboard';
 import { CreateWorkspace } from '../../pageobjects/dashboard/CreateWorkspace';
 import { Logger } from '../../utils/Logger';
-import { TIMEOUT_CONSTANTS } from '../../constants/TIMEOUT_CONSTANTS';
 
 suite(`"Create Empty Workspace sample" test ${BASE_TEST_CONSTANTS.TEST_ENVIRONMENT}`, function (): void {
 	const workspaceHandlingTests: WorkspaceHandlingTests = e2eContainer.get(CLASSES.WorkspaceHandlingTests);
@@ -103,26 +102,6 @@ suite(`"Create Empty Workspace sample" test ${BASE_TEST_CONSTANTS.TEST_ENVIRONME
 		expect(await createWorkspace.isCreateNewWorkspaceCheckboxChecked(), '"Create New" checkbox should be unchecked').to.be.false;
 
 		await workspaceHandlingTests.createAndOpenWorkspace(stackName, false);
-
-		// verify no duplicate workspace warning appeared (wait a few seconds to be sure)
-		let alertAppeared: boolean = false;
-		try {
-			await dashboard.waitExistingWorkspaceFoundAlert(TIMEOUT_CONSTANTS.TS_COMMON_DASHBOARD_WAIT_TIMEOUT);
-			alertAppeared = true;
-		} catch (e) {
-			// expected - alert should not appear
-		}
-		// tODO: Remove this workaround after fixing https://redhat.atlassian.net/browse/CRW-10546
-		// empty Workspace sample should generate unique names and not show duplicate workspace warning
-		if (alertAppeared) {
-			Logger.error(
-				'KNOWN ISSUE: Duplicate workspace warning appeared for Empty Workspace sample. ' +
-					'This should not happen as Empty Workspace generates unique names. ' +
-					'Skipping test - no workspace will be created.'
-			);
-			this.skip();
-		}
-
 		await workspaceHandlingTests.obtainWorkspaceNameFromStartingPage();
 		thirdWorkspaceName = WorkspaceHandlingTests.getWorkspaceName();
 		expect(thirdWorkspaceName, 'Third workspace name should not be empty').not.empty;

--- a/tests/e2e/specs/miscellaneous/CreateWorkspaceWithExistingNameFromEmptyWorkspaceSample.spec.ts
+++ b/tests/e2e/specs/miscellaneous/CreateWorkspaceWithExistingNameFromEmptyWorkspaceSample.spec.ts
@@ -20,6 +20,7 @@ import { BASE_TEST_CONSTANTS } from '../../constants/BASE_TEST_CONSTANTS';
 import { Dashboard } from '../../pageobjects/dashboard/Dashboard';
 import { CreateWorkspace } from '../../pageobjects/dashboard/CreateWorkspace';
 import { Logger } from '../../utils/Logger';
+import { TIMEOUT_CONSTANTS } from '../../constants/TIMEOUT_CONSTANTS';
 
 suite(`"Create Empty Workspace sample" test ${BASE_TEST_CONSTANTS.TEST_ENVIRONMENT}`, function (): void {
 	const workspaceHandlingTests: WorkspaceHandlingTests = e2eContainer.get(CLASSES.WorkspaceHandlingTests);
@@ -33,19 +34,19 @@ suite(`"Create Empty Workspace sample" test ${BASE_TEST_CONSTANTS.TEST_ENVIRONME
 
 	let firstWorkspaceName: string;
 	let secondWorkspaceName: string;
+	let thirdWorkspaceName: string;
 
 	suiteSetup('Login', async function (): Promise<void> {
 		await loginTests.loginIntoChe();
 	});
 
-	async function waitDashboardPage(): Promise<void> {
+	async function openCreateWorkspacePage(): Promise<void> {
 		await dashboard.openDashboard();
 		await dashboard.waitPage();
 		await browserTabsUtil.closeAllTabsExceptCurrent();
 
 		await dashboard.clickCreateWorkspaceButton();
 		await createWorkspace.waitPage();
-		expect(await createWorkspace.isCreateNewWorkspaceCheckboxChecked()).to.be.true;
 	}
 
 	async function waitWorkspaceReadiness(): Promise<void> {
@@ -60,37 +61,90 @@ suite(`"Create Empty Workspace sample" test ${BASE_TEST_CONSTANTS.TEST_ENVIRONME
 		}
 	}
 
-	test('Verify "Create New" is on and a new workspace is created without warnings', async function (): Promise<void> {
-		await waitDashboardPage();
+	test('Step 1-2: Verify "Create New" is ON by default and create first Empty Workspace', async function (): Promise<void> {
+		await openCreateWorkspacePage();
 
 		// verify "Create New" checkbox is checked by default
-		expect(await createWorkspace.isCreateNewWorkspaceCheckboxChecked()).to.be.true;
+		expect(await createWorkspace.isCreateNewWorkspaceCheckboxChecked(), '"Create New" checkbox should be checked by default').to.be
+			.true;
+
 		await workspaceHandlingTests.createAndOpenWorkspace(stackName, true);
 		await workspaceHandlingTests.obtainWorkspaceNameFromStartingPage();
-		registerRunningWorkspace(WorkspaceHandlingTests.getWorkspaceName());
-		await waitWorkspaceReadiness();
-
 		firstWorkspaceName = WorkspaceHandlingTests.getWorkspaceName();
+		expect(firstWorkspaceName, 'First workspace name should not be empty').not.empty;
+		registerRunningWorkspace(firstWorkspaceName);
+
+		await waitWorkspaceReadiness();
 	});
 
-	test('Verify "Create New" is off and a new workspace is created', async function (): Promise<void> {
-		await waitDashboardPage();
+	test('Step 3: Create second Empty Workspace with "Create New" ON - should succeed without warnings', async function (): Promise<void> {
+		await openCreateWorkspacePage();
 
-		expect(await createWorkspace.isCreateNewWorkspaceCheckboxChecked()).to.be.true;
-		await workspaceHandlingTests.createAndOpenWorkspace(stackName, false);
+		// verify "Create New" checkbox is still checked
+		expect(await createWorkspace.isCreateNewWorkspaceCheckboxChecked(), '"Create New" checkbox should be checked').to.be.true;
+
+		await workspaceHandlingTests.createAndOpenWorkspace(stackName, true);
 		await workspaceHandlingTests.obtainWorkspaceNameFromStartingPage();
-		registerRunningWorkspace(WorkspaceHandlingTests.getWorkspaceName());
+		secondWorkspaceName = WorkspaceHandlingTests.getWorkspaceName();
+		expect(secondWorkspaceName, 'Second workspace name should not be empty').not.empty;
+		registerRunningWorkspace(secondWorkspaceName);
+
 		await waitWorkspaceReadiness();
 
-		secondWorkspaceName = WorkspaceHandlingTests.getWorkspaceName();
-
 		// empty Workspace sample generates unique names, so workspaces should have different names
-		expect(WorkspaceHandlingTests.getWorkspaceName()).not.to.be.equal(firstWorkspaceName);
+		expect(secondWorkspaceName, 'Second workspace should have a different name than the first one').not.to.be.equal(firstWorkspaceName);
+	});
+
+	test('Step 4-5: Turn OFF "Create New" and create third Empty Workspace - should succeed without warnings', async function (): Promise<void> {
+		await openCreateWorkspacePage();
+
+		// turn off "Create New" checkbox
+		await createWorkspace.setCreateNewWorkspaceCheckbox(false);
+		expect(await createWorkspace.isCreateNewWorkspaceCheckboxChecked(), '"Create New" checkbox should be unchecked').to.be.false;
+
+		await workspaceHandlingTests.createAndOpenWorkspace(stackName, false);
+
+		// verify no duplicate workspace warning appeared (wait a few seconds to be sure)
+		let alertAppeared: boolean = false;
+		try {
+			await dashboard.waitExistingWorkspaceFoundAlert(TIMEOUT_CONSTANTS.TS_COMMON_DASHBOARD_WAIT_TIMEOUT);
+			alertAppeared = true;
+		} catch (e) {
+			// expected - alert should not appear
+		}
+		// tODO: Remove this workaround after fixing https://github.com/eclipse/che/issues/XXXXX
+		// empty Workspace sample should generate unique names and not show duplicate workspace warning
+		if (alertAppeared) {
+			Logger.error(
+				'KNOWN ISSUE: Duplicate workspace warning appeared for Empty Workspace sample. ' +
+					'This should not happen as Empty Workspace generates unique names. ' +
+					'Skipping test - no workspace will be created.'
+			);
+			this.skip();
+		}
+
+		await workspaceHandlingTests.obtainWorkspaceNameFromStartingPage();
+		thirdWorkspaceName = WorkspaceHandlingTests.getWorkspaceName();
+		expect(thirdWorkspaceName, 'Third workspace name should not be empty').not.empty;
+		registerRunningWorkspace(thirdWorkspaceName);
+
+		await waitWorkspaceReadiness();
+
+		// empty Workspace sample generates unique names, so all workspaces should have different names
+		expect(thirdWorkspaceName, 'Third workspace should have a different name than the first one').not.to.be.equal(firstWorkspaceName);
+		expect(thirdWorkspaceName, 'Third workspace should have a different name than the second one').not.to.be.equal(secondWorkspaceName);
 	});
 
 	suiteTeardown('Stop and delete all created workspaces', async function (): Promise<void> {
-		await workspaceHandlingTests.stopAndRemoveWorkspace(firstWorkspaceName);
-		await workspaceHandlingTests.stopAndRemoveWorkspace(secondWorkspaceName);
+		if (firstWorkspaceName) {
+			await workspaceHandlingTests.stopAndRemoveWorkspace(firstWorkspaceName);
+		}
+		if (secondWorkspaceName) {
+			await workspaceHandlingTests.stopAndRemoveWorkspace(secondWorkspaceName);
+		}
+		if (thirdWorkspaceName) {
+			await workspaceHandlingTests.stopAndRemoveWorkspace(thirdWorkspaceName);
+		}
 	});
 
 	suiteTeardown('Unregister running workspace', function (): void {

--- a/tests/e2e/specs/miscellaneous/CreateWorkspaceWithExistingNameFromEmptyWorkspaceSample.spec.ts
+++ b/tests/e2e/specs/miscellaneous/CreateWorkspaceWithExistingNameFromEmptyWorkspaceSample.spec.ts
@@ -112,7 +112,7 @@ suite(`"Create Empty Workspace sample" test ${BASE_TEST_CONSTANTS.TEST_ENVIRONME
 		} catch (e) {
 			// expected - alert should not appear
 		}
-		// tODO: Remove this workaround after fixing https://github.com/eclipse/che/issues/XXXXX
+		// tODO: Remove this workaround after fixing https://redhat.atlassian.net/browse/CRW-10546
 		// empty Workspace sample should generate unique names and not show duplicate workspace warning
 		if (alertAppeared) {
 			Logger.error(


### PR DESCRIPTION
### What does this PR do?
Add a workaround for a known issue where the duplicate workspace warning incorrectly appears when creating an Empty Workspace with "Create New" checkbox OFF.

When creating an Empty Workspace sample with "Create New" checkbox turned OFF, the dashboard shows a duplicate workspace warning even though Empty Workspace should always generate unique names.

#### Workaround
When the duplicate workspace warning appears unexpectedly, the test now:
- Logs an error message describing the known issue
- Skips the test to avoid false failures

#### Changes
- Added try-catch block to detect unexpected duplicate workspace warning
- Added `this.skip()` with error logging when the warning appears
- Added TODO comment referencing the issue to be fixed

#### Note
This workaround should be removed after fixing https://redhat.atlassian.net/browse/CRW-10546

#### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
