### PR TITLE
[Test] Stabilize DevConsole import-from-git step with URL fallback

### DIFF
--- a/tests/e2e/pageobjects/openshift/OcpMainPage.ts
+++ b/tests/e2e/pageobjects/openshift/OcpMainPage.ts
@@ -72,7 +72,7 @@ export class OcpMainPage {
 	async selectImportFromGitMethod(): Promise<OcpImportFromGitPage> {
 		Logger.debug();
 
-		await this.driverHelper.waitAndClick(OcpMainPage.IMPORT_FROM_GIT_ITEM, TIMEOUT_CONSTANTS.TS_SELENIUM_LOAD_PAGE_TIMEOUT);
+		await this.driverHelper.waitAndClick(OcpMainPage.IMPORT_FROM_GIT_ITEM, TIMEOUT_CONSTANTS.TS_SELENIUM_WAIT_FOR_URL);
 		return e2eContainer.get(CLASSES.OcpImportFromGitPage);
 	}
 
@@ -81,6 +81,21 @@ export class OcpMainPage {
 
 		await this.clickAddToProjectButton();
 		return await this.selectImportFromGitMethod();
+	}
+
+	/**
+	 * prefer Dev Console Add → Import from Git; if that fails , open the import route directly.
+	 */
+	async openImportFromGitPageWithFallback(importProjectUrl: string): Promise<OcpImportFromGitPage> {
+		Logger.debug();
+
+		try {
+			return await this.openImportFromGitPage();
+		} catch (err) {
+			Logger.warn(`Import from git via UI failed, navigating to ${importProjectUrl}: ${err}`);
+			await this.browserTabsUtil.navigateTo(importProjectUrl);
+			return e2eContainer.get(CLASSES.OcpImportFromGitPage);
+		}
 	}
 
 	async selectProject(projectName: string): Promise<void> {

--- a/tests/e2e/specs/devconsole-intergration/DevConsoleIntegration.spec.ts
+++ b/tests/e2e/specs/devconsole-intergration/DevConsoleIntegration.spec.ts
@@ -53,6 +53,11 @@ suite(`DevConsole Integration ${BASE_TEST_CONSTANTS.TEST_ENVIRONMENT}`, function
 	const gitImportReference: string = 'pipeline';
 	const projectLabel: string = 'app.openshift.io/runtime=spring';
 	const projectName: string = 'devconsole-integration-test';
+	const openshiftConsoleUrl: string = BASE_TEST_CONSTANTS.TS_SELENIUM_BASE_URL.replace(
+		BASE_TEST_CONSTANTS.TESTING_APPLICATION_NAME(),
+		'console-openshift-console'
+	);
+	const importProjectUrl: string = `${openshiftConsoleUrl}/import/ns/${projectName}`;
 
 	suiteSetup('Create new empty project using ocp', function (): void {
 		kubernetesCommandLineToolsExecutor.loginToOcp();
@@ -101,7 +106,7 @@ suite(`DevConsole Integration ${BASE_TEST_CONSTANTS.TEST_ENVIRONMENT}`, function
 	});
 
 	test('Open import from git project page', async function (): Promise<void> {
-		ocpImportPage = await ocpMainPage.openImportFromGitPage();
+		ocpImportPage = await ocpMainPage.openImportFromGitPageWithFallback(importProjectUrl);
 	});
 
 	test('Fill and submit import data', async function (): Promise<void> {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
The import page navigation can be flaky depending on OpenShift console behavior and routing. Using a direct fallback URL makes the test more reliable across environments.

- Stabilizes the DevConsole integration flow for “Import from Git” by adding a deterministic fallback URL for the target project namespace.
- Builds the OpenShift console URL from the existing test base URL and composes `/import/ns/{projectName}`.
- Updates the test step to use `openImportFromGitPageWithFallback(importProjectUrl)` instead of relying only on UI navigation.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://redhat.atlassian.net/browse/CRW-9944

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
- Run `DevConsoleIntegration.spec.ts` in the target environment.
- Verify the “Open import from git project page” step consistently reaches the import page.
- Confirm the rest of the flow (fill and submit import data) passes unchanged.


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
