### PR TITLE
fix(e2e): update Actions button locator for workspace-specific aria-label

### DIFF
--- a/tests/e2e/.prettierignore
+++ b/tests/e2e/.prettierignore
@@ -1,5 +1,4 @@
 build
-.claude
 **report
 **results**
 dist

--- a/tests/e2e/.prettierignore
+++ b/tests/e2e/.prettierignore
@@ -1,4 +1,5 @@
 build
+.claude
 **report
 **results**
 dist

--- a/tests/e2e/pageobjects/dashboard/Workspaces.ts
+++ b/tests/e2e/pageobjects/dashboard/Workspaces.ts
@@ -227,12 +227,12 @@ export class Workspaces {
 	}
 
 	private getActionsLocator(workspaceName: string): By {
-		return By.xpath(`${this.getWorkspaceListItemLocator(workspaceName).value}/td/button[@aria-label='Actions']`);
+		return By.xpath(`${this.getWorkspaceListItemLocator(workspaceName).value}/td/button[@aria-label='Actions for ${workspaceName}']`);
 	}
 
 	/* private getExpandedActionsLocator(workspaceName: string): By {
 		return By.xpath(
-			`${this.getWorkspaceListItemLocator(workspaceName).value}//button[@aria-label='Actions' and @aria-expanded='true']`
+			`${this.getWorkspaceListItemLocator(workspaceName).value}//button[@aria-label='Actions for ${workspaceName}' and @aria-expanded='true']`
 		);
 	}*/
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
The dashboard changed `aria-label="Actions"` to `aria-label="Actions for {workspace name}"` ([che-dashboard#1544](https://github.com/eclipse-che/che-dashboard/pull/1544)). This broke the E2E `Workspaces` page object locator. Updated `getActionsLocator()` and `getExpandedActionsLocator()` in `Workspaces.ts` to use the new workspace-specific `aria-label` pattern.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
it needs for https://redhat.atlassian.net/browse/CRW-10287

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
