### PR TITLE
[Test] Automate rename workspace test

### DIFF
--- a/tests/e2e/pageobjects/dashboard/workspace-details/WorkspaceDetails.ts
+++ b/tests/e2e/pageobjects/dashboard/workspace-details/WorkspaceDetails.ts
@@ -29,6 +29,10 @@ export class WorkspaceDetails {
 	private static readonly CLOSE_STORAGE_TYPE_INFO_BUTTON: By = By.xpath('//button[@aria-label="Close"]');
 	private static readonly STORAGE_TYPE_DOC_LINK: By = By.xpath('//div/p/a');
 	private static readonly DEVFILE_DOC_LINK: By = By.xpath('//a[text()="Devfile Documentation"]');
+	private static readonly RENAME_WORKSPACE_BUTTON: By = By.xpath('//button[@title="Edit Workspace Name"]');
+	private static readonly RENAME_WORKSPACE_INPUT: By = By.id('edit-workspace-name');
+	private static readonly RENAME_SAVE_BUTTON: By = By.xpath('//button[@data-testid="edit-workspace-name-save"]');
+	private static readonly RENAME_CANCEL_BUTTON: By = By.xpath('//button[@data-testid="edit-workspace-name-cancel"]');
 
 	constructor(
 		@inject(CLASSES.DriverHelper)
@@ -142,6 +146,43 @@ export class WorkspaceDetails {
 
 	async getDevfileDocumentationLink(): Promise<string> {
 		return await this.driverHelper.waitAndGetElementAttribute(WorkspaceDetails.DEVFILE_DOC_LINK, 'href');
+	}
+
+	/**
+	 * devSpaces Dashboard does not allow editing the workspace display name while the workspace is running.
+	 */
+	async waitRenameWorkspaceNotPossibleWhileWorkspaceRunning(): Promise<void> {
+		Logger.debug();
+
+		await this.driverHelper.waitDisappearance(WorkspaceDetails.RENAME_WORKSPACE_BUTTON);
+	}
+
+	/**
+	 * rename a stopped workspace from the Overview tab (fill name + save).
+	 */
+	async renameStoppedWorkspaceTo(newDisplayName: string): Promise<void> {
+		Logger.debug(`newDisplayName: "${newDisplayName}"`);
+		await this.driverHelper.waitAndClick(WorkspaceDetails.RENAME_WORKSPACE_BUTTON, TIMEOUT_CONSTANTS.TS_SELENIUM_LOAD_PAGE_TIMEOUT);
+		await this.driverHelper.type(WorkspaceDetails.RENAME_WORKSPACE_INPUT, newDisplayName);
+		await this.driverHelper.waitAndClick(WorkspaceDetails.RENAME_SAVE_BUTTON);
+		await this.waitWorkspaceTitle(newDisplayName);
+	}
+
+	async attemptRenameWorkspaceName(desiredName: string): Promise<void> {
+		Logger.debug(`desiredName: "${desiredName}"`);
+
+		await this.driverHelper.waitAndClick(WorkspaceDetails.RENAME_WORKSPACE_BUTTON, TIMEOUT_CONSTANTS.TS_SELENIUM_LOAD_PAGE_TIMEOUT);
+		await this.driverHelper.type(WorkspaceDetails.RENAME_WORKSPACE_INPUT, desiredName);
+		await this.driverHelper.waitAttributePresent(
+			WorkspaceDetails.RENAME_SAVE_BUTTON,
+			'disabled',
+			TIMEOUT_CONSTANTS.TS_COMMON_DASHBOARD_WAIT_TIMEOUT
+		);
+		await this.closeRenameWorkspaceForm();
+	}
+
+	async closeRenameWorkspaceForm(): Promise<void> {
+		await this.driverHelper.waitAndClick(WorkspaceDetails.RENAME_CANCEL_BUTTON, TIMEOUT_CONSTANTS.TS_SELENIUM_LOAD_PAGE_TIMEOUT);
 	}
 
 	private getWorkspaceTitleLocator(workspaceName: string): By {

--- a/tests/e2e/pageobjects/dashboard/workspace-details/WorkspaceDetails.ts
+++ b/tests/e2e/pageobjects/dashboard/workspace-details/WorkspaceDetails.ts
@@ -151,38 +151,45 @@ export class WorkspaceDetails {
 	/**
 	 * devSpaces Dashboard does not allow editing the workspace display name while the workspace is running.
 	 */
-	async waitRenameWorkspaceNotPossibleWhileWorkspaceRunning(): Promise<void> {
+	async checkRenameButtonIsAbsent(): Promise<void> {
 		Logger.debug();
 
 		await this.driverHelper.waitDisappearance(WorkspaceDetails.RENAME_WORKSPACE_BUTTON);
 	}
 
-	/**
-	 * rename a stopped workspace from the Overview tab (fill name + save).
-	 */
-	async renameStoppedWorkspaceTo(newDisplayName: string): Promise<void> {
-		Logger.debug(`newDisplayName: "${newDisplayName}"`);
+	async openRenameWorkspaceForm(): Promise<void> {
+		Logger.debug();
 		await this.driverHelper.waitAndClick(WorkspaceDetails.RENAME_WORKSPACE_BUTTON, TIMEOUT_CONSTANTS.TS_SELENIUM_LOAD_PAGE_TIMEOUT);
-		await this.driverHelper.type(WorkspaceDetails.RENAME_WORKSPACE_INPUT, newDisplayName);
-		await this.driverHelper.waitAndClick(WorkspaceDetails.RENAME_SAVE_BUTTON);
-		await this.waitWorkspaceTitle(newDisplayName);
 	}
 
-	async attemptRenameWorkspaceName(desiredName: string): Promise<void> {
-		Logger.debug(`desiredName: "${desiredName}"`);
+	async typeWorkspaceName(name: string): Promise<void> {
+		Logger.debug(`name: "${name}"`);
+		await this.driverHelper.type(WorkspaceDetails.RENAME_WORKSPACE_INPUT, name);
+	}
 
-		await this.driverHelper.waitAndClick(WorkspaceDetails.RENAME_WORKSPACE_BUTTON, TIMEOUT_CONSTANTS.TS_SELENIUM_LOAD_PAGE_TIMEOUT);
-		await this.driverHelper.type(WorkspaceDetails.RENAME_WORKSPACE_INPUT, desiredName);
+	async waitSaveButtonIsDisabled(): Promise<void> {
+		Logger.debug();
 		await this.driverHelper.waitAttributePresent(
 			WorkspaceDetails.RENAME_SAVE_BUTTON,
 			'disabled',
 			TIMEOUT_CONSTANTS.TS_COMMON_DASHBOARD_WAIT_TIMEOUT
 		);
-		await this.closeRenameWorkspaceForm();
 	}
 
-	async closeRenameWorkspaceForm(): Promise<void> {
+	async cancelRenameWorkspace(): Promise<void> {
+		Logger.debug();
 		await this.driverHelper.waitAndClick(WorkspaceDetails.RENAME_CANCEL_BUTTON, TIMEOUT_CONSTANTS.TS_SELENIUM_LOAD_PAGE_TIMEOUT);
+	}
+
+	/**
+	 * rename a workspace from the Overview tab (fill name + save).
+	 */
+	async renameWorkspace(newDisplayName: string): Promise<void> {
+		Logger.debug(`newDisplayName: "${newDisplayName}"`);
+		await this.openRenameWorkspaceForm();
+		await this.typeWorkspaceName(newDisplayName);
+		await this.driverHelper.waitAndClick(WorkspaceDetails.RENAME_SAVE_BUTTON);
+		await this.waitWorkspaceTitle(newDisplayName);
 	}
 
 	private getWorkspaceTitleLocator(workspaceName: string): By {

--- a/tests/e2e/specs/miscellaneous/RenameWorkspace.spec.ts
+++ b/tests/e2e/specs/miscellaneous/RenameWorkspace.spec.ts
@@ -1,0 +1,135 @@
+/** *******************************************************************
+ * copyright (c) 2026 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+import { e2eContainer } from '../../configs/inversify.config';
+import { CLASSES } from '../../configs/inversify.types';
+import { expect } from 'chai';
+import { WorkspaceHandlingTests } from '../../tests-library/WorkspaceHandlingTests';
+import { ProjectAndFileTests } from '../../tests-library/ProjectAndFileTests';
+import { LoginTests } from '../../tests-library/LoginTests';
+import { registerRunningWorkspace } from '../MochaHooks';
+import { BrowserTabsUtil } from '../../utils/BrowserTabsUtil';
+import { BASE_TEST_CONSTANTS } from '../../constants/BASE_TEST_CONSTANTS';
+import { Dashboard } from '../../pageobjects/dashboard/Dashboard';
+import { Workspaces } from '../../pageobjects/dashboard/Workspaces';
+import { WorkspaceDetails } from '../../pageobjects/dashboard/workspace-details/WorkspaceDetails';
+import { TIMEOUT_CONSTANTS } from '../../constants/TIMEOUT_CONSTANTS';
+
+const stackName: string = BASE_TEST_CONSTANTS.TS_SELENIUM_DASHBOARD_SAMPLE_NAME || 'Empty Workspace';
+const RENAMED_WORKSPACE_NAME: string = 'new-ws';
+
+suite(`Rename workspace ${BASE_TEST_CONSTANTS.TEST_ENVIRONMENT}`, function (): void {
+	const workspaceHandlingTests: WorkspaceHandlingTests = e2eContainer.get(CLASSES.WorkspaceHandlingTests);
+	const projectAndFileTests: ProjectAndFileTests = e2eContainer.get(CLASSES.ProjectAndFileTests);
+	const loginTests: LoginTests = e2eContainer.get(CLASSES.LoginTests);
+	const browserTabsUtil: BrowserTabsUtil = e2eContainer.get(CLASSES.BrowserTabsUtil);
+	const dashboard: Dashboard = e2eContainer.get(CLASSES.Dashboard);
+	const workspaces: Workspaces = e2eContainer.get(CLASSES.Workspaces);
+	const workspaceDetails: WorkspaceDetails = e2eContainer.get(CLASSES.WorkspaceDetails);
+
+	let firstWorkspaceName: string = '';
+	let secondWorkspaceName: string = '';
+
+	async function openDashboardWorkspacesList(): Promise<void> {
+		await dashboard.openDashboard();
+		await dashboard.clickWorkspacesButton();
+		await workspaces.waitPage();
+	}
+
+	async function openWorkspaceDetailsOverview(workspaceName: string): Promise<void> {
+		await openDashboardWorkspacesList();
+		await workspaces.clickWorkspaceListItemLink(workspaceName);
+		await workspaceDetails.waitWorkspaceTitle(workspaceName);
+		await workspaceDetails.waitLoaderDisappearance();
+	}
+
+	suiteSetup('Login', async function (): Promise<void> {
+		await loginTests.loginIntoChe();
+	});
+
+	test(`Create workspace from sample (${stackName})`, async function (): Promise<void> {
+		await workspaceHandlingTests.createAndOpenWorkspace(stackName);
+		await workspaceHandlingTests.obtainWorkspaceNameFromStartingPage();
+		firstWorkspaceName = WorkspaceHandlingTests.getWorkspaceName();
+		registerRunningWorkspace(firstWorkspaceName);
+
+		await projectAndFileTests.waitWorkspaceReadinessForCheCodeEditor();
+	});
+
+	test('Workspace details: rename must not be available while the workspace is running', async function (): Promise<void> {
+		await openWorkspaceDetailsOverview(firstWorkspaceName);
+		await workspaceDetails.waitRenameWorkspaceNotPossibleWhileWorkspaceRunning();
+	});
+
+	test('Stop the first workspace from the dashboard', async function (): Promise<void> {
+		await workspaceHandlingTests.stopWorkspace(firstWorkspaceName);
+		await browserTabsUtil.closeAllTabsExceptCurrent();
+	});
+
+	test(`Rename stopped workspace to "${RENAMED_WORKSPACE_NAME}" from workspace details`, async function (): Promise<void> {
+		await openWorkspaceDetailsOverview(firstWorkspaceName);
+		await workspaceDetails.renameStoppedWorkspaceTo(RENAMED_WORKSPACE_NAME);
+		firstWorkspaceName = RENAMED_WORKSPACE_NAME;
+	});
+
+	test(`Dashboard lists and details show "${RENAMED_WORKSPACE_NAME}"`, async function (): Promise<void> {
+		await openDashboardWorkspacesList();
+		await workspaces.waitWorkspaceListItem(RENAMED_WORKSPACE_NAME, TIMEOUT_CONSTANTS.TS_SELENIUM_LOAD_PAGE_TIMEOUT);
+		await workspaces.clickWorkspaceListItemLink(RENAMED_WORKSPACE_NAME);
+		await workspaceDetails.waitWorkspaceTitle(RENAMED_WORKSPACE_NAME);
+	});
+
+	test(`Start "${RENAMED_WORKSPACE_NAME}" and wait until it is Running`, async function (): Promise<void> {
+		await openDashboardWorkspacesList();
+
+		await workspaceHandlingTests.openWorkspace(RENAMED_WORKSPACE_NAME);
+		await workspaceHandlingTests.obtainWorkspaceNameFromStartingPage();
+		const startedWorkspaceName: string = WorkspaceHandlingTests.getWorkspaceName();
+		expect(WorkspaceHandlingTests.getWorkspaceName()).equal(RENAMED_WORKSPACE_NAME);
+		registerRunningWorkspace(startedWorkspaceName);
+		await projectAndFileTests.waitWorkspaceReadinessForCheCodeEditor();
+	});
+
+	test(`Stop "${RENAMED_WORKSPACE_NAME}" again`, async function (): Promise<void> {
+		await workspaceHandlingTests.stopWorkspace(RENAMED_WORKSPACE_NAME);
+		await browserTabsUtil.closeAllTabsExceptCurrent();
+	});
+
+	test(`Workspace details: setting name to "${RENAMED_WORKSPACE_NAME}" when it is already the current name is rejected`, async function (): Promise<void> {
+		await openWorkspaceDetailsOverview(RENAMED_WORKSPACE_NAME);
+		await workspaceDetails.attemptRenameWorkspaceName(RENAMED_WORKSPACE_NAME);
+	});
+
+	test(`Create a second workspace from sample (${stackName})`, async function (): Promise<void> {
+		await workspaceHandlingTests.createAndOpenWorkspace(stackName);
+		await workspaceHandlingTests.obtainWorkspaceNameFromStartingPage();
+		secondWorkspaceName = WorkspaceHandlingTests.getWorkspaceName();
+		registerRunningWorkspace(secondWorkspaceName);
+		await projectAndFileTests.waitWorkspaceReadinessForCheCodeEditor();
+	});
+
+	test(`Second workspace details: rename to "${RENAMED_WORKSPACE_NAME}" shows conflict and does not apply`, async function (): Promise<void> {
+		await workspaceHandlingTests.stopWorkspace(secondWorkspaceName);
+		await browserTabsUtil.closeAllTabsExceptCurrent();
+
+		await openWorkspaceDetailsOverview(secondWorkspaceName);
+		await workspaceDetails.attemptRenameWorkspaceName(RENAMED_WORKSPACE_NAME);
+	});
+
+	suiteTeardown('Stop and delete workspaces created in this suite', async function (): Promise<void> {
+		await openDashboardWorkspacesList();
+
+		await dashboard.deleteStoppedWorkspaceByUI(secondWorkspaceName);
+		await dashboard.deleteStoppedWorkspaceByUI(RENAMED_WORKSPACE_NAME);
+	});
+
+	suiteTeardown('Unregister running workspace', function (): void {
+		registerRunningWorkspace('');
+	});
+});

--- a/tests/e2e/specs/miscellaneous/RenameWorkspace.spec.ts
+++ b/tests/e2e/specs/miscellaneous/RenameWorkspace.spec.ts
@@ -64,7 +64,7 @@ suite(`Rename workspace ${BASE_TEST_CONSTANTS.TEST_ENVIRONMENT}`, function (): v
 
 	test('Workspace details: rename must not be available while the workspace is running', async function (): Promise<void> {
 		await openWorkspaceDetailsOverview(firstWorkspaceName);
-		await workspaceDetails.waitRenameWorkspaceNotPossibleWhileWorkspaceRunning();
+		await workspaceDetails.checkRenameButtonIsAbsent();
 	});
 
 	test('Stop the first workspace from the dashboard', async function (): Promise<void> {
@@ -74,7 +74,7 @@ suite(`Rename workspace ${BASE_TEST_CONSTANTS.TEST_ENVIRONMENT}`, function (): v
 
 	test(`Rename stopped workspace to "${RENAMED_WORKSPACE_NAME}" from workspace details`, async function (): Promise<void> {
 		await openWorkspaceDetailsOverview(firstWorkspaceName);
-		await workspaceDetails.renameStoppedWorkspaceTo(RENAMED_WORKSPACE_NAME);
+		await workspaceDetails.renameWorkspace(RENAMED_WORKSPACE_NAME);
 		firstWorkspaceName = RENAMED_WORKSPACE_NAME;
 	});
 
@@ -103,7 +103,10 @@ suite(`Rename workspace ${BASE_TEST_CONSTANTS.TEST_ENVIRONMENT}`, function (): v
 
 	test(`Workspace details: setting name to "${RENAMED_WORKSPACE_NAME}" when it is already the current name is rejected`, async function (): Promise<void> {
 		await openWorkspaceDetailsOverview(RENAMED_WORKSPACE_NAME);
-		await workspaceDetails.attemptRenameWorkspaceName(RENAMED_WORKSPACE_NAME);
+		await workspaceDetails.openRenameWorkspaceForm();
+		await workspaceDetails.typeWorkspaceName(RENAMED_WORKSPACE_NAME);
+		await workspaceDetails.waitSaveButtonIsDisabled();
+		await workspaceDetails.cancelRenameWorkspace();
 	});
 
 	test(`Create a second workspace from sample (${stackName})`, async function (): Promise<void> {
@@ -119,7 +122,10 @@ suite(`Rename workspace ${BASE_TEST_CONSTANTS.TEST_ENVIRONMENT}`, function (): v
 		await browserTabsUtil.closeAllTabsExceptCurrent();
 
 		await openWorkspaceDetailsOverview(secondWorkspaceName);
-		await workspaceDetails.attemptRenameWorkspaceName(RENAMED_WORKSPACE_NAME);
+		await workspaceDetails.openRenameWorkspaceForm();
+		await workspaceDetails.typeWorkspaceName(RENAMED_WORKSPACE_NAME);
+		await workspaceDetails.waitSaveButtonIsDisabled();
+		await workspaceDetails.cancelRenameWorkspace();
 	});
 
 	suiteTeardown('Stop and delete workspaces created in this suite', async function (): Promise<void> {

--- a/tests/e2e/suites/online-ocp/UITest.suite.ts
+++ b/tests/e2e/suites/online-ocp/UITest.suite.ts
@@ -15,5 +15,6 @@ import '../../specs/dashboard-samples/Documentation.spec';
 import '../../specs/devconsole-intergration/DevConsoleIntegration.spec';
 import '../../specs/miscellaneous/CreateWorkspaceWithExistingNameFromGitUrl.spec';
 import '../../specs/miscellaneous/KubedockPodmanTest.spec';
+import '../../specs/miscellaneous/RenameWorkspace.spec';
 import '../../specs/miscellaneous/WorkspaceWithParent.spec';
 import '../../specs/miscellaneous/PredefinedNamespace.spec';

--- a/tests/e2e/tests-library/WorkspaceHandlingTests.ts
+++ b/tests/e2e/tests-library/WorkspaceHandlingTests.ts
@@ -19,6 +19,7 @@ import { ApiUrlResolver } from '../utils/workspace/ApiUrlResolver';
 import { TIMEOUT_CONSTANTS } from '../constants/TIMEOUT_CONSTANTS';
 import { DriverHelper } from '../utils/DriverHelper';
 import { By, error } from 'selenium-webdriver';
+import { Workspaces } from '../pageobjects/dashboard/Workspaces';
 
 @injectable()
 export class WorkspaceHandlingTests {
@@ -38,7 +39,9 @@ export class WorkspaceHandlingTests {
 		@inject(CLASSES.ApiUrlResolver)
 		private readonly apiUrlResolver: ApiUrlResolver,
 		@inject(CLASSES.DriverHelper)
-		private readonly driverHelper: DriverHelper
+		private readonly driverHelper: DriverHelper,
+		@inject(CLASSES.Workspaces)
+		private readonly workspaces: Workspaces
 	) {}
 
 	static getWorkspaceName(): string {
@@ -59,6 +62,13 @@ export class WorkspaceHandlingTests {
 		await this.createWorkspace.setCreateNewWorkspaceCheckbox(createNewWorkspace);
 		WorkspaceHandlingTests.parentGUID = await this.browserTabsUtil.getCurrentWindowHandle();
 		await this.createWorkspace.clickOnSampleNoEditorSelection(stack);
+		await this.browserTabsUtil.waitAndSwitchToAnotherWindow(WorkspaceHandlingTests.parentGUID, TIMEOUT_CONSTANTS.TS_IDE_LOAD_TIMEOUT);
+	}
+
+	async openWorkspace(workspaceName: string): Promise<void> {
+		await this.workspaces.clickOpenButton(workspaceName);
+		await this.apiUrlResolver.getWorkspacesApiUrl();
+		WorkspaceHandlingTests.parentGUID = await this.browserTabsUtil.getCurrentWindowHandle();
 		await this.browserTabsUtil.waitAndSwitchToAnotherWindow(WorkspaceHandlingTests.parentGUID, TIMEOUT_CONSTANTS.TS_IDE_LOAD_TIMEOUT);
 	}
 

--- a/tests/e2e/utils/DriverHelper.ts
+++ b/tests/e2e/utils/DriverHelper.ts
@@ -419,6 +419,24 @@ export class DriverHelper {
 		);
 	}
 
+	/**
+	 * waits until the attribute is present on the element (e.g. boolean HTML `disabled`),
+	 * without requiring a specific attribute value.
+	 */
+	async waitAttributePresent(elementLocator: By, attribute: string, timeout: number): Promise<void> {
+		Logger.trace(`${elementLocator}`);
+
+		await this.driver.wait(
+			async (): Promise<boolean> => {
+				const attributeValue: string | null = await this.waitAndGetElementAttribute(elementLocator, attribute, timeout);
+
+				return attributeValue != null;
+			},
+			timeout,
+			`The '${attribute}' attribute is not present on '${elementLocator}'`
+		);
+	}
+
 	async type(elementLocator: By, text: string, timeout: number = TIMEOUT_CONSTANTS.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM): Promise<void> {
 		const polling: number = TIMEOUT_CONSTANTS.TS_SELENIUM_DEFAULT_POLLING;
 		const attempts: number = Math.ceil(timeout / polling);


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Automate “Rename Workspace” test 

Test scenario:

1. Create workspace from sample.
2. Wait on workspace being started and running.
3. Go to workspace details page and ensure rename is not possible.
4. Stop workspace.
5. Go to workspace details page and rename it to the “new-ws”.
6. Ensure workspace name has been changed to the “new-ws” all over User Dashboard
7. Start workspace and ensure running workspace can be opened from the User Dashboard.
8. Stop workspace.
9. Go to workspace details page and ensure workspace name can’t be changed to the “new-ws”.
10. Create new workspace.
11. Go to workspace new workspace details page and rename it to the “new-ws” name.
12. Observe error status and that it is not possible to rename workspace to “new-ws”.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://redhat.atlassian.net/browse/CRW-10665

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->

<details>
<summary>Test logs</summary>

```text
          ▼ Dashboard.waitPage
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ WorkspaceHandlingTests.createAndOpenWorkspace - fetching user kubernetes namespace, storing auth token by getting workspaces API URL.
          ▼ ApiUrlResolver.obtainUserNamespace
            ‣ ApiUrlResolver.obtainUserNamespace - USER_NAMESPACE.length = 0, calling kubernetes API
            ‣ DriverHelper.getDriver
(node:23598) Warning: Setting the NODE_TLS_REJECT_UNAUTHORIZED environment variable to '0' makes TLS connections and HTTPS requests insecure by disabling certificate verification.
(Use `node --trace-warnings ...` to show where the warning was created)
          ▼ ApiUrlResolver.obtainUserNamespace - kubeapi success: admin-devspaces
          ▼ Dashboard.clickCreateWorkspaceButton
            ‣ DriverHelper.waitAndClick - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ CreateWorkspace.waitPage
          ▼ CreateWorkspace.waitTitleContains - text: "Create Workspace"
            ‣ DriverHelper.waitVisibility - By(xpath, //h1[contains(text(), 'Create Workspace')])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ CreateWorkspace.setCreateNewWorkspaceCheckbox - checked: true
          ▼ CreateWorkspace.isCreateNewWorkspaceCheckboxChecked
            ‣ DriverHelper.waitPresence - By(css selector, *[id="create-new-if-exist-switch"])
          ▼ CreateWorkspace.setCreateNewWorkspaceCheckbox - Checkbox is already set, no action needed
          ▼ BrowserTabsUtil.getCurrentWindowHandle
            ‣ DriverHelper.getDriver
          ▼ CreateWorkspace.clickOnSampleNoEditorSelection - sampleName: "Python"
            ‣ CreateWorkspace.getSampleLocator - sampleName: Python, used default editor
            ‣ DriverHelper.waitAndClick - By(xpath, //div[contains(@id, 'sample-card') and text()='Python'])
            ‣ DriverHelper.waitVisibility - By(xpath, //div[contains(@id, 'sample-card') and text()='Python'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ BrowserTabsUtil.waitAndSwitchToAnotherWindow
            ‣ DriverHelper.waitUntilTrue
          ▼ BrowserTabsUtil.getAllWindowHandles
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.getAllWindowHandles
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.switchToWindow
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - obtained starting workspace getText():Starting workspace python-hello-world
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - trimmed workspace name from getText():python-hello-world
      • WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - obtained workspace name from workspace loader page: python-hello-world
          ▼ registerRunningWorkspace - with workspaceName:python-hello-world
          ▼ ProjectAndFileTests.waitWorkspaceReadinessForCheCodeEditor - waiting for editor.
            ‣ DriverHelper.waitVisibility - By(css selector, .monaco-workbench)
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #2, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #3, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #4, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #5, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #6, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #7, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #8, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #9, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #10, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #11, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #12, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #13, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #14, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #15, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #16, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #17, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #18, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #19, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #20, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #21, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #22, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #23, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ ProjectAndFileTests.waitWorkspaceReadinessForCheCodeEditor - editor was opened in 27430 seconds.
    ✔ Create workspace from sample (Python) (35019ms)
          ▼ Dashboard.openDashboard
            ‣ DriverHelper.navigateToUrl
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
          ▼ Dashboard.openDashboard - No alert detected
          ▼ Dashboard.waitPage
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Dashboard.clickWorkspacesButton
            ‣ DriverHelper.waitAndClick - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitPage
            ‣ DriverHelper.waitVisibility - By(css selector, button[aria-label="Add Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.clickWorkspaceListItemLink - "python-hello-world"
            ‣ DriverHelper.waitAndClick - By(xpath, //tr[td//span[text()='python-hello-world']]//span[text()='python-hello-world'])
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='python-hello-world']]//span[text()='python-hello-world'])
          ▼ DriverHelper.waitVisibility - stale element error - {"name":"StaleElementReferenceError","remoteStacktrace":"#0 0x555853794afa <unknown>\n#1 0x555853196265 <unknown>\n#2 0x55585319d111 <unknown>\n#3 0x55585319fc5b <unknown>\n#4 0x555853232a99 <unknown>\n#5 0x555853231969 <unknown>\n#6 0x5558531dc5cf <unknown>\n#7 0x5558531dd391 <unknown>\n#8 0x555853759fdb <unknown>\n#9 0x55585375cf9d <unknown>\n#10 0x555853746798 <unknown>\n#11 0x55585375db30 <unknown>\n#12 0x55585372d210 <unknown>\n#13 0x555853781d48 <unknown>\n#14 0x555853781f18 <unknown>\n#15 0x55585379356e <unknown>\n#16 0x7fc7f38f3f34 start_thread\n#17 0x7fc7f397736c __clone3\n"}
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.waitAndClick - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='python-hello-world']]//span[text()='python-hello-world'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ WorkspaceDetails.waitWorkspaceTitle - title: "python-hello-world"
            ‣ DriverHelper.waitVisibility - By(xpath, //h1[text()='python-hello-world'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ WorkspaceDetails.waitLoaderDisappearance
            ‣ DriverHelper.waitDisappearance - By(css selector, workspace-details-overview md-progress-linear)
            ‣ DriverHelper.waitDisappearanceBoolean - By(css selector, workspace-details-overview md-progress-linear)
            ‣ DriverHelper.isVisible - By(css selector, workspace-details-overview md-progress-linear)
          ▼ WorkspaceDetails.waitRenameWorkspaceNotPossibleWhileWorkspaceRunning
            ‣ DriverHelper.waitDisappearance - By(xpath, //button[@title="Edit Workspace Name"])
            ‣ DriverHelper.waitDisappearanceBoolean - By(xpath, //button[@title="Edit Workspace Name"])
            ‣ DriverHelper.isVisible - By(xpath, //button[@title="Edit Workspace Name"])
    ✔ Workspace details: rename must not be available while the workspace is running
          ▼ Dashboard.openDashboard
            ‣ DriverHelper.navigateToUrl
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
          ▼ Dashboard.openDashboard - No alert detected
          ▼ Dashboard.waitPage
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Dashboard.stopWorkspaceByUI - "python-hello-world"
          ▼ Dashboard.clickWorkspacesButton
            ‣ DriverHelper.waitAndClick - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitPage
            ‣ DriverHelper.waitVisibility - By(css selector, button[aria-label="Add Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitWorkspaceListItem - "python-hello-world"
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='python-hello-world']])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.stopWorkspaceByActionsButton
          ▼ Workspaces.waitWorkspaceListItem - "python-hello-world"
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='python-hello-world']])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.openActionsPopup - for the 'python-hello-world' list item
          ▼ Workspaces.clickActionsButton - of the 'python-hello-world' list item
            ‣ DriverHelper.waitAndClick - By(xpath, //tr[td//span[text()='python-hello-world']]/td/button[@aria-label='Actions for python-hello-world'])
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='python-hello-world']]/td/button[@aria-label='Actions for python-hello-world'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitActionsPopup - of the 'python-hello-world' list item
            ‣ DriverHelper.waitVisibility - By(css selector, div[class*="workspaceActionSelector"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.clickActionsStopWorkspaceButton - for the 'python-hello-world' list item
            ‣ DriverHelper.waitAndClick - By(css selector, button[aria-label="Action: Stop Workspace"])
            ‣ DriverHelper.waitVisibility - By(css selector, button[aria-label="Action: Stop Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitWorkspaceWithStoppedStatus - "python-hello-world"
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='python-hello-world']]//span[@data-testid='workspace-status-indicator' and @aria-label='Workspace status is Stopped'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ BrowserTabsUtil.closeAllTabsExceptCurrent
          ▼ BrowserTabsUtil.getAllWindowHandles
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.getCurrentWindowHandle
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.switchToWindow
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.switchToWindow
            ‣ DriverHelper.getDriver
    ✔ Stop the first workspace from the dashboard
          ▼ Dashboard.openDashboard
            ‣ DriverHelper.navigateToUrl
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
          ▼ Dashboard.openDashboard - No alert detected
          ▼ Dashboard.waitPage
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Dashboard.clickWorkspacesButton
            ‣ DriverHelper.waitAndClick - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitPage
            ‣ DriverHelper.waitVisibility - By(css selector, button[aria-label="Add Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.clickWorkspaceListItemLink - "python-hello-world"
            ‣ DriverHelper.waitAndClick - By(xpath, //tr[td//span[text()='python-hello-world']]//span[text()='python-hello-world'])
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='python-hello-world']]//span[text()='python-hello-world'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ WorkspaceDetails.waitWorkspaceTitle - title: "python-hello-world"
            ‣ DriverHelper.waitVisibility - By(xpath, //h1[text()='python-hello-world'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ WorkspaceDetails.waitLoaderDisappearance
            ‣ DriverHelper.waitDisappearance - By(css selector, workspace-details-overview md-progress-linear)
            ‣ DriverHelper.waitDisappearanceBoolean - By(css selector, workspace-details-overview md-progress-linear)
            ‣ DriverHelper.isVisible - By(css selector, workspace-details-overview md-progress-linear)
          ▼ WorkspaceDetails.renameStoppedWorkspaceTo - newDisplayName: "new-ws"
            ‣ DriverHelper.waitAndClick - By(xpath, //button[@title="Edit Workspace Name"])
            ‣ DriverHelper.waitVisibility - By(xpath, //button[@title="Edit Workspace Name"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.type - By(css selector, *[id="edit-workspace-name"]) text: new-ws
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="edit-workspace-name"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitAndClick - By(xpath, //button[@data-testid="edit-workspace-name-save"])
            ‣ DriverHelper.waitVisibility - By(xpath, //button[@data-testid="edit-workspace-name-save"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ WorkspaceDetails.waitWorkspaceTitle - title: "new-ws"
            ‣ DriverHelper.waitVisibility - By(xpath, //h1[text()='new-ws'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
    ✔ Rename stopped workspace to "new-ws" from workspace details
          ▼ Dashboard.openDashboard
            ‣ DriverHelper.navigateToUrl
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
          ▼ Dashboard.openDashboard - No alert detected
          ▼ Dashboard.waitPage
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Dashboard.clickWorkspacesButton
            ‣ DriverHelper.waitAndClick - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitPage
            ‣ DriverHelper.waitVisibility - By(css selector, button[aria-label="Add Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitWorkspaceListItem - "new-ws"
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='new-ws']])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.clickWorkspaceListItemLink - "new-ws"
            ‣ DriverHelper.waitAndClick - By(xpath, //tr[td//span[text()='new-ws']]//span[text()='new-ws'])
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='new-ws']]//span[text()='new-ws'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ DriverHelper.waitAndClick - By(xpath, //tr[td//span[text()='new-ws']]//span[text()='new-ws']) - {"name":"StaleElementReferenceError","remoteStacktrace":"#0 0x555853794afa <unknown>\n#1 0x555853196265 <unknown>\n#2 0x55585319d111 <unknown>\n#3 0x55585319f95b <unknown>\n#4 0x55585319fa03 <unknown>\n#5 0x5558531eacd0 <unknown>\n#6 0x5558531de437 <unknown>\n#7 0x5558531dde07 <unknown>\n#8 0x555853231969 <unknown>\n#9 0x5558531dc5cf <unknown>\n#10 0x5558531dd391 <unknown>\n#11 0x555853759fdb <unknown>\n#12 0x55585375cf9d <unknown>\n#13 0x555853746798 <unknown>\n#14 0x55585375db30 <unknown>\n#15 0x55585372d210 <unknown>\n#16 0x555853781d48 <unknown>\n#17 0x555853781f18 <unknown>\n#18 0x55585379356e <unknown>\n#19 0x7fc7f38f3f34 start_thread\n#20 0x7fc7f397736c __clone3\n"}
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='new-ws']]//span[text()='new-ws'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ WorkspaceDetails.waitWorkspaceTitle - title: "new-ws"
            ‣ DriverHelper.waitVisibility - By(xpath, //h1[text()='new-ws'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
    ✔ Dashboard lists and details show "new-ws"
          ▼ Dashboard.openDashboard
            ‣ DriverHelper.navigateToUrl
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
          ▼ Dashboard.openDashboard - No alert detected
          ▼ Dashboard.waitPage
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Dashboard.clickWorkspacesButton
            ‣ DriverHelper.waitAndClick - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitPage
            ‣ DriverHelper.waitVisibility - By(css selector, button[aria-label="Add Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.clickOpenButton
            ‣ DriverHelper.waitAndClick - By(xpath, //tr[td//span[text()='new-ws']]//button/span[text()='Open'])
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='new-ws']]//button/span[text()='Open'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ ApiUrlResolver.obtainUserNamespace - admin-devspaces
          ▼ BrowserTabsUtil.getCurrentWindowHandle
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.waitAndSwitchToAnotherWindow
            ‣ DriverHelper.waitUntilTrue
          ▼ BrowserTabsUtil.getAllWindowHandles
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.getAllWindowHandles
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.switchToWindow
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - obtained starting workspace getText():Starting workspace new-ws
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - trimmed workspace name from getText():new-ws
      • WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - obtained workspace name from workspace loader page: new-ws
          ▼ registerRunningWorkspace - with workspaceName:new-ws
          ▼ ProjectAndFileTests.waitWorkspaceReadinessForCheCodeEditor - waiting for editor.
            ‣ DriverHelper.waitVisibility - By(css selector, .monaco-workbench)
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #2, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #3, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #4, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #5, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #6, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #7, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #8, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #9, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #10, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #11, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #12, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #13, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #14, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #15, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #16, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #17, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ ProjectAndFileTests.waitWorkspaceReadinessForCheCodeEditor - editor was opened in 20908 seconds.
    ✔ Start "new-ws" and wait until it is Running
          ▼ Dashboard.openDashboard
            ‣ DriverHelper.navigateToUrl
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
          ▼ Dashboard.openDashboard - No alert detected
          ▼ Dashboard.waitPage
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Dashboard.stopWorkspaceByUI - "new-ws"
          ▼ Dashboard.clickWorkspacesButton
            ‣ DriverHelper.waitAndClick - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitPage
            ‣ DriverHelper.waitVisibility - By(css selector, button[aria-label="Add Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitWorkspaceListItem - "new-ws"
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='new-ws']])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.stopWorkspaceByActionsButton
          ▼ Workspaces.waitWorkspaceListItem - "new-ws"
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='new-ws']])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.openActionsPopup - for the 'new-ws' list item
          ▼ Workspaces.clickActionsButton - of the 'new-ws' list item
            ‣ DriverHelper.waitAndClick - By(xpath, //tr[td//span[text()='new-ws']]/td/button[@aria-label='Actions for new-ws'])
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='new-ws']]/td/button[@aria-label='Actions for new-ws'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitActionsPopup - of the 'new-ws' list item
            ‣ DriverHelper.waitVisibility - By(css selector, div[class*="workspaceActionSelector"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.clickActionsStopWorkspaceButton - for the 'new-ws' list item
            ‣ DriverHelper.waitAndClick - By(css selector, button[aria-label="Action: Stop Workspace"])
            ‣ DriverHelper.waitVisibility - By(css selector, button[aria-label="Action: Stop Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitWorkspaceWithStoppedStatus - "new-ws"
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='new-ws']]//span[@data-testid='workspace-status-indicator' and @aria-label='Workspace status is Stopped'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ BrowserTabsUtil.closeAllTabsExceptCurrent
          ▼ BrowserTabsUtil.getAllWindowHandles
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.getCurrentWindowHandle
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.switchToWindow
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.switchToWindow
            ‣ DriverHelper.getDriver
    ✔ Stop "new-ws" again
          ▼ Dashboard.openDashboard
            ‣ DriverHelper.navigateToUrl
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
          ▼ Dashboard.openDashboard - No alert detected
          ▼ Dashboard.waitPage
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Dashboard.clickWorkspacesButton
            ‣ DriverHelper.waitAndClick - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitPage
            ‣ DriverHelper.waitVisibility - By(css selector, button[aria-label="Add Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.clickWorkspaceListItemLink - "new-ws"
            ‣ DriverHelper.waitAndClick - By(xpath, //tr[td//span[text()='new-ws']]//span[text()='new-ws'])
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='new-ws']]//span[text()='new-ws'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ WorkspaceDetails.waitWorkspaceTitle - title: "new-ws"
            ‣ DriverHelper.waitVisibility - By(xpath, //h1[text()='new-ws'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ WorkspaceDetails.waitLoaderDisappearance
            ‣ DriverHelper.waitDisappearance - By(css selector, workspace-details-overview md-progress-linear)
            ‣ DriverHelper.waitDisappearanceBoolean - By(css selector, workspace-details-overview md-progress-linear)
            ‣ DriverHelper.isVisible - By(css selector, workspace-details-overview md-progress-linear)
          ▼ WorkspaceDetails.attemptRenameWorkspaceName - desiredName: "new-ws"
            ‣ DriverHelper.waitAndClick - By(xpath, //button[@title="Edit Workspace Name"])
            ‣ DriverHelper.waitVisibility - By(xpath, //button[@title="Edit Workspace Name"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.type - By(css selector, *[id="edit-workspace-name"]) text: new-ws
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="edit-workspace-name"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitAttributePresent - By(xpath, //button[@data-testid="edit-workspace-name-save"])
            ‣ DriverHelper.waitAndGetElementAttribute - By(xpath, //button[@data-testid="edit-workspace-name-save"]) attribute: 'disabled'
            ‣ DriverHelper.waitVisibility - By(xpath, //button[@data-testid="edit-workspace-name-save"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitAndClick - By(xpath, //button[@data-testid="edit-workspace-name-cancel"])
            ‣ DriverHelper.waitVisibility - By(xpath, //button[@data-testid="edit-workspace-name-cancel"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
    ✔ Workspace details: setting name to "new-ws" when it is already the current name is rejected
          ▼ Dashboard.clickWorkspacesButton
            ‣ DriverHelper.waitAndClick - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Dashboard.waitPage
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ WorkspaceHandlingTests.createAndOpenWorkspace - fetching user kubernetes namespace, storing auth token by getting workspaces API URL.
          ▼ ApiUrlResolver.obtainUserNamespace - admin-devspaces
          ▼ Dashboard.clickCreateWorkspaceButton
            ‣ DriverHelper.waitAndClick - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ CreateWorkspace.waitPage
          ▼ CreateWorkspace.waitTitleContains - text: "Create Workspace"
            ‣ DriverHelper.waitVisibility - By(xpath, //h1[contains(text(), 'Create Workspace')])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ CreateWorkspace.setCreateNewWorkspaceCheckbox - checked: true
          ▼ CreateWorkspace.isCreateNewWorkspaceCheckboxChecked
            ‣ DriverHelper.waitPresence - By(css selector, *[id="create-new-if-exist-switch"])
          ▼ CreateWorkspace.setCreateNewWorkspaceCheckbox - Checkbox is already set, no action needed
          ▼ BrowserTabsUtil.getCurrentWindowHandle
            ‣ DriverHelper.getDriver
          ▼ CreateWorkspace.clickOnSampleNoEditorSelection - sampleName: "Python"
            ‣ CreateWorkspace.getSampleLocator - sampleName: Python, used default editor
            ‣ DriverHelper.waitAndClick - By(xpath, //div[contains(@id, 'sample-card') and text()='Python'])
            ‣ DriverHelper.waitVisibility - By(xpath, //div[contains(@id, 'sample-card') and text()='Python'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ BrowserTabsUtil.waitAndSwitchToAnotherWindow
            ‣ DriverHelper.waitUntilTrue
          ▼ BrowserTabsUtil.getAllWindowHandles
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.getAllWindowHandles
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.switchToWindow
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - obtained starting workspace getText():Starting workspace python-hello-world-aubw
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - trimmed workspace name from getText():python-hello-world-aubw
      • WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - obtained workspace name from workspace loader page: python-hello-world-aubw
          ▼ registerRunningWorkspace - with workspaceName:python-hello-world-aubw
          ▼ ProjectAndFileTests.waitWorkspaceReadinessForCheCodeEditor - waiting for editor.
            ‣ DriverHelper.waitVisibility - By(css selector, .monaco-workbench)
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #2, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #3, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #4, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #5, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #6, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #7, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #8, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #9, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #10, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #11, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #12, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #13, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #14, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #15, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #16, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #17, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #18, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #19, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #20, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #21, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #22, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #23, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ ProjectAndFileTests.waitWorkspaceReadinessForCheCodeEditor - editor was opened in 28247 seconds.
    ✔ Create a second workspace from sample (Python) (33969ms)
          ▼ Dashboard.openDashboard
            ‣ DriverHelper.navigateToUrl
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
          ▼ Dashboard.openDashboard - No alert detected
          ▼ Dashboard.waitPage
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Dashboard.stopWorkspaceByUI - "python-hello-world-aubw"
          ▼ Dashboard.clickWorkspacesButton
            ‣ DriverHelper.waitAndClick - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitPage
            ‣ DriverHelper.waitVisibility - By(css selector, button[aria-label="Add Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitWorkspaceListItem - "python-hello-world-aubw"
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='python-hello-world-aubw']])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.stopWorkspaceByActionsButton
          ▼ Workspaces.waitWorkspaceListItem - "python-hello-world-aubw"
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='python-hello-world-aubw']])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.openActionsPopup - for the 'python-hello-world-aubw' list item
          ▼ Workspaces.clickActionsButton - of the 'python-hello-world-aubw' list item
            ‣ DriverHelper.waitAndClick - By(xpath, //tr[td//span[text()='python-hello-world-aubw']]/td/button[@aria-label='Actions for python-hello-world-aubw'])
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='python-hello-world-aubw']]/td/button[@aria-label='Actions for python-hello-world-aubw'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitActionsPopup - of the 'python-hello-world-aubw' list item
            ‣ DriverHelper.waitVisibility - By(css selector, div[class*="workspaceActionSelector"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.clickActionsStopWorkspaceButton - for the 'python-hello-world-aubw' list item
            ‣ DriverHelper.waitAndClick - By(css selector, button[aria-label="Action: Stop Workspace"])
            ‣ DriverHelper.waitVisibility - By(css selector, button[aria-label="Action: Stop Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitWorkspaceWithStoppedStatus - "python-hello-world-aubw"
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='python-hello-world-aubw']]//span[@data-testid='workspace-status-indicator' and @aria-label='Workspace status is Stopped'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ BrowserTabsUtil.closeAllTabsExceptCurrent
          ▼ BrowserTabsUtil.getAllWindowHandles
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.getCurrentWindowHandle
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.switchToWindow
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.switchToWindow
            ‣ DriverHelper.getDriver
          ▼ Dashboard.openDashboard
            ‣ DriverHelper.navigateToUrl
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
          ▼ Dashboard.openDashboard - No alert detected
          ▼ Dashboard.waitPage
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Dashboard.clickWorkspacesButton
            ‣ DriverHelper.waitAndClick - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitPage
            ‣ DriverHelper.waitVisibility - By(css selector, button[aria-label="Add Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.clickWorkspaceListItemLink - "python-hello-world-aubw"
            ‣ DriverHelper.waitAndClick - By(xpath, //tr[td//span[text()='python-hello-world-aubw']]//span[text()='python-hello-world-aubw'])
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='python-hello-world-aubw']]//span[text()='python-hello-world-aubw'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ WorkspaceDetails.waitWorkspaceTitle - title: "python-hello-world-aubw"
            ‣ DriverHelper.waitVisibility - By(xpath, //h1[text()='python-hello-world-aubw'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ WorkspaceDetails.waitLoaderDisappearance
            ‣ DriverHelper.waitDisappearance - By(css selector, workspace-details-overview md-progress-linear)
            ‣ DriverHelper.waitDisappearanceBoolean - By(css selector, workspace-details-overview md-progress-linear)
            ‣ DriverHelper.isVisible - By(css selector, workspace-details-overview md-progress-linear)
          ▼ WorkspaceDetails.attemptRenameWorkspaceName - desiredName: "new-ws"
            ‣ DriverHelper.waitAndClick - By(xpath, //button[@title="Edit Workspace Name"])
            ‣ DriverHelper.waitVisibility - By(xpath, //button[@title="Edit Workspace Name"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.type - By(css selector, *[id="edit-workspace-name"]) text: new-ws
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="edit-workspace-name"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitAttributePresent - By(xpath, //button[@data-testid="edit-workspace-name-save"])
            ‣ DriverHelper.waitAndGetElementAttribute - By(xpath, //button[@data-testid="edit-workspace-name-save"]) attribute: 'disabled'
            ‣ DriverHelper.waitVisibility - By(xpath, //button[@data-testid="edit-workspace-name-save"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitAndClick - By(xpath, //button[@data-testid="edit-workspace-name-cancel"])
            ‣ DriverHelper.waitVisibility - By(xpath, //button[@data-testid="edit-workspace-name-cancel"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
    ✔ Second workspace details: rename to "new-ws" shows conflict and does not apply
          ▼ Dashboard.openDashboard
            ‣ DriverHelper.navigateToUrl
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
          ▼ Dashboard.openDashboard - No alert detected
          ▼ Dashboard.waitPage
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Dashboard.clickWorkspacesButton
            ‣ DriverHelper.waitAndClick - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitPage
            ‣ DriverHelper.waitVisibility - By(css selector, button[aria-label="Add Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Dashboard.deleteStoppedWorkspaceByUI - "python-hello-world-aubw"
          ▼ Dashboard.clickWorkspacesButton
            ‣ DriverHelper.waitAndClick - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitPage
            ‣ DriverHelper.waitVisibility - By(css selector, button[aria-label="Add Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitWorkspaceListItem - "python-hello-world-aubw"
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='python-hello-world-aubw']])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.deleteWorkspaceByActionsButton
          ▼ Workspaces.waitWorkspaceListItem - "python-hello-world-aubw"
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='python-hello-world-aubw']])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.openActionsPopup - for the 'python-hello-world-aubw' list item
          ▼ Workspaces.clickActionsButton - of the 'python-hello-world-aubw' list item
            ‣ DriverHelper.waitAndClick - By(xpath, //tr[td//span[text()='python-hello-world-aubw']]/td/button[@aria-label='Actions for python-hello-world-aubw'])
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='python-hello-world-aubw']]/td/button[@aria-label='Actions for python-hello-world-aubw'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitActionsPopup - of the 'python-hello-world-aubw' list item
            ‣ DriverHelper.waitVisibility - By(css selector, div[class*="workspaceActionSelector"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.clickActionsDeleteButton - for the 'python-hello-world-aubw' list item
            ‣ DriverHelper.waitAndClick - By(css selector, button[aria-label="Action: Delete Workspace"])
            ‣ DriverHelper.waitVisibility - By(css selector, button[aria-label="Action: Delete Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitDeleteWorkspaceConfirmationWindow
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@aria-label="Delete workspaces confirmation window"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.clickToDeleteConfirmationCheckbox
            ‣ DriverHelper.waitAndClick - By(xpath, //input[@data-testid="confirmation-checkbox"])
            ‣ DriverHelper.waitVisibility - By(xpath, //input[@data-testid="confirmation-checkbox"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitAndClickEnabledConfirmationWindowDeleteButton
            ‣ DriverHelper.waitAndClick - By(xpath, //button[@data-testid="delete-workspace-button" and not(@disabled)])
            ‣ DriverHelper.waitVisibility - By(xpath, //button[@data-testid="delete-workspace-button" and not(@disabled)])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitPage
            ‣ DriverHelper.waitVisibility - By(css selector, button[aria-label="Add Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitWorkspaceListItemAbsence - "python-hello-world-aubw"
            ‣ DriverHelper.waitDisappearance - By(xpath, //tr[td//span[text()='python-hello-world-aubw']])
            ‣ DriverHelper.waitDisappearanceBoolean - By(xpath, //tr[td//span[text()='python-hello-world-aubw']])
            ‣ DriverHelper.isVisible - By(xpath, //tr[td//span[text()='python-hello-world-aubw']])
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.isVisible - By(xpath, //tr[td//span[text()='python-hello-world-aubw']])
          ▼ Dashboard.deleteStoppedWorkspaceByUI - "new-ws"
          ▼ Dashboard.clickWorkspacesButton
            ‣ DriverHelper.waitAndClick - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitPage
            ‣ DriverHelper.waitVisibility - By(css selector, button[aria-label="Add Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitWorkspaceListItem - "new-ws"
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='new-ws']])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.deleteWorkspaceByActionsButton
          ▼ Workspaces.waitWorkspaceListItem - "new-ws"
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='new-ws']])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.openActionsPopup - for the 'new-ws' list item
          ▼ Workspaces.clickActionsButton - of the 'new-ws' list item
            ‣ DriverHelper.waitAndClick - By(xpath, //tr[td//span[text()='new-ws']]/td/button[@aria-label='Actions for new-ws'])
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='new-ws']]/td/button[@aria-label='Actions for new-ws'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitActionsPopup - of the 'new-ws' list item
            ‣ DriverHelper.waitVisibility - By(css selector, div[class*="workspaceActionSelector"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.clickActionsDeleteButton - for the 'new-ws' list item
            ‣ DriverHelper.waitAndClick - By(css selector, button[aria-label="Action: Delete Workspace"])
            ‣ DriverHelper.waitVisibility - By(css selector, button[aria-label="Action: Delete Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitDeleteWorkspaceConfirmationWindow
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@aria-label="Delete workspaces confirmation window"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.clickToDeleteConfirmationCheckbox
            ‣ DriverHelper.waitAndClick - By(xpath, //input[@data-testid="confirmation-checkbox"])
            ‣ DriverHelper.waitVisibility - By(xpath, //input[@data-testid="confirmation-checkbox"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitAndClickEnabledConfirmationWindowDeleteButton
            ‣ DriverHelper.waitAndClick - By(xpath, //button[@data-testid="delete-workspace-button" and not(@disabled)])
            ‣ DriverHelper.waitVisibility - By(xpath, //button[@data-testid="delete-workspace-button" and not(@disabled)])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitPage
            ‣ DriverHelper.waitVisibility - By(css selector, button[aria-label="Add Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitWorkspaceListItemAbsence - "new-ws"
            ‣ DriverHelper.waitDisappearance - By(xpath, //tr[td//span[text()='new-ws']])
            ‣ DriverHelper.waitDisappearanceBoolean - By(xpath, //tr[td//span[text()='new-ws']])
            ‣ DriverHelper.isVisible - By(xpath, //tr[td//span[text()='new-ws']])
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.isVisible - By(xpath, //tr[td//span[text()='new-ws']])
          ▼     at che/tests/e2e/specs/MochaHooks.ts:39:12 - delete workspace name


  10 passing (2m)
```

</details>

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
