### PR TITLE
Implement test case "Create a workspace from sample with the same name of an existing workspace"

### DIFF
--- a/tests/e2e/specs/miscellaneous/CreateWorkspaceWithExistingNameFromSample.spec.ts
+++ b/tests/e2e/specs/miscellaneous/CreateWorkspaceWithExistingNameFromSample.spec.ts
@@ -62,7 +62,7 @@ suite(`"Create workspace from sample with existing name" test ${BASE_TEST_CONSTA
 		).not.undefined;
 	}
 
-	test('Step 1-2: Verify "Create New" is on by default and create first workspace from sample', async function (): Promise<void> {
+	test('Verify "Create New" is on by default and create first workspace from sample', async function (): Promise<void> {
 		await openCreateWorkspacePage();
 
 		// verify "Create New" checkbox is checked by default
@@ -79,7 +79,7 @@ suite(`"Create workspace from sample with existing name" test ${BASE_TEST_CONSTA
 		expect(firstWorkspaceName, 'First workspace name should not be empty').not.empty;
 	});
 
-	test('Step 3: Turn off "Create New" and verify existing workspace opens', async function (): Promise<void> {
+	test('Turn off "Create New" and verify existing workspace opens', async function (): Promise<void> {
 		await openCreateWorkspacePage();
 
 		// turn off "Create New" checkbox
@@ -97,7 +97,7 @@ suite(`"Create workspace from sample with existing name" test ${BASE_TEST_CONSTA
 		expect(WorkspaceHandlingTests.getWorkspaceName(), 'The existing workspace should be opened').to.be.equal(firstWorkspaceName);
 	});
 
-	test('Step 4-5: Turn on "Create New" and verify new workspace is created without warnings', async function (): Promise<void> {
+	test('Turn on "Create New" and verify new workspace is created without warnings', async function (): Promise<void> {
 		await openCreateWorkspacePage();
 
 		// turn on "Create New" checkbox
@@ -116,7 +116,7 @@ suite(`"Create workspace from sample with existing name" test ${BASE_TEST_CONSTA
 		expect(secondWorkspaceName, 'A new workspace with different name should be created').not.to.be.equal(firstWorkspaceName);
 	});
 
-	test('Step 6-9: Turn off "Create New", verify warning with workspace list, and select second workspace', async function (): Promise<void> {
+	test('Turn off "Create New", verify warning with workspace list, and select second workspace', async function (): Promise<void> {
 		await openCreateWorkspacePage();
 
 		// turn off "Create New" checkbox

--- a/tests/e2e/specs/miscellaneous/CreateWorkspaceWithExistingNameFromSample.spec.ts
+++ b/tests/e2e/specs/miscellaneous/CreateWorkspaceWithExistingNameFromSample.spec.ts
@@ -1,0 +1,154 @@
+/** *******************************************************************
+ * copyright (c) 2020-2026 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+import { e2eContainer } from '../../configs/inversify.config';
+import { ViewSection } from 'monaco-page-objects';
+import { CLASSES } from '../../configs/inversify.types';
+import { expect } from 'chai';
+import { WorkspaceHandlingTests } from '../../tests-library/WorkspaceHandlingTests';
+import { ProjectAndFileTests } from '../../tests-library/ProjectAndFileTests';
+import { LoginTests } from '../../tests-library/LoginTests';
+import { registerRunningWorkspace } from '../MochaHooks';
+import { BrowserTabsUtil } from '../../utils/BrowserTabsUtil';
+import { BASE_TEST_CONSTANTS } from '../../constants/BASE_TEST_CONSTANTS';
+import { Dashboard } from '../../pageobjects/dashboard/Dashboard';
+import { CreateWorkspace } from '../../pageobjects/dashboard/CreateWorkspace';
+import { TIMEOUT_CONSTANTS } from '../../constants/TIMEOUT_CONSTANTS';
+
+const sampleName: string = 'Java Lombok';
+
+suite(`"Create workspace from sample with existing name" test ${BASE_TEST_CONSTANTS.TEST_ENVIRONMENT}`, function (): void {
+	const workspaceHandlingTests: WorkspaceHandlingTests = e2eContainer.get(CLASSES.WorkspaceHandlingTests);
+	const projectAndFileTests: ProjectAndFileTests = e2eContainer.get(CLASSES.ProjectAndFileTests);
+	const loginTests: LoginTests = e2eContainer.get(CLASSES.LoginTests);
+	const browserTabsUtil: BrowserTabsUtil = e2eContainer.get(CLASSES.BrowserTabsUtil);
+	const dashboard: Dashboard = e2eContainer.get(CLASSES.Dashboard);
+	const createWorkspace: CreateWorkspace = e2eContainer.get(CLASSES.CreateWorkspace);
+
+	let projectSection: ViewSection;
+	let firstWorkspaceName: string;
+	let secondWorkspaceName: string;
+
+	suiteSetup('Login', async function (): Promise<void> {
+		await loginTests.loginIntoChe();
+	});
+
+	async function openCreateWorkspacePage(): Promise<void> {
+		await dashboard.openDashboard();
+		await dashboard.waitPage();
+		await browserTabsUtil.closeAllTabsExceptCurrent();
+
+		await dashboard.clickCreateWorkspaceButton();
+		await createWorkspace.waitPage();
+	}
+
+	async function waitWorkspaceReadiness(): Promise<void> {
+		await workspaceHandlingTests.obtainWorkspaceNameFromStartingPage();
+		registerRunningWorkspace(WorkspaceHandlingTests.getWorkspaceName());
+
+		await projectAndFileTests.waitWorkspaceReadinessForCheCodeEditor();
+		projectSection = await projectAndFileTests.getProjectViewSession();
+		expect(await projectAndFileTests.getProjectTreeItem(projectSection, 'lombok-project-sample'), 'Project folder was not imported').not
+			.undefined;
+		expect(
+			await projectAndFileTests.getProjectTreeItem(projectSection, BASE_TEST_CONSTANTS.TS_SELENIUM_PROJECT_ROOT_FILE_NAME),
+			'Project files were not imported'
+		).not.undefined;
+	}
+
+	test('Step 1-2: Verify "Create New" is on by default and create first workspace from sample', async function (): Promise<void> {
+		await openCreateWorkspacePage();
+
+		// verify "Create New" checkbox is checked by default
+		expect(await createWorkspace.isCreateNewWorkspaceCheckboxChecked(), '"Create New" checkbox should be checked by default').to.be
+			.true;
+
+		// create workspace from sample
+		const parentGUID: string = await browserTabsUtil.getCurrentWindowHandle();
+		await createWorkspace.clickOnSampleNoEditorSelection(sampleName);
+		await browserTabsUtil.waitAndSwitchToAnotherWindow(parentGUID, TIMEOUT_CONSTANTS.TS_IDE_LOAD_TIMEOUT);
+
+		await waitWorkspaceReadiness();
+		firstWorkspaceName = WorkspaceHandlingTests.getWorkspaceName();
+		expect(firstWorkspaceName, 'First workspace name should not be empty').not.empty;
+	});
+
+	test('Step 3: Turn off "Create New" and verify existing workspace opens', async function (): Promise<void> {
+		await openCreateWorkspacePage();
+
+		// turn off "Create New" checkbox
+		await createWorkspace.setCreateNewWorkspaceCheckbox(false);
+		expect(await createWorkspace.isCreateNewWorkspaceCheckboxChecked(), '"Create New" checkbox should be unchecked').to.be.false;
+
+		// click on the same sample
+		const parentGUID: string = await browserTabsUtil.getCurrentWindowHandle();
+		await createWorkspace.clickOnSampleNoEditorSelection(sampleName);
+		await browserTabsUtil.waitAndSwitchToAnotherWindow(parentGUID, TIMEOUT_CONSTANTS.TS_IDE_LOAD_TIMEOUT);
+
+		await waitWorkspaceReadiness();
+
+		// verify the same workspace was opened (not a new one)
+		expect(WorkspaceHandlingTests.getWorkspaceName(), 'The existing workspace should be opened').to.be.equal(firstWorkspaceName);
+	});
+
+	test('Step 4-5: Turn on "Create New" and verify new workspace is created without warnings', async function (): Promise<void> {
+		await openCreateWorkspacePage();
+
+		// turn on "Create New" checkbox
+		await createWorkspace.setCreateNewWorkspaceCheckbox(true);
+		expect(await createWorkspace.isCreateNewWorkspaceCheckboxChecked(), '"Create New" checkbox should be checked').to.be.true;
+
+		// click on the same sample
+		const parentGUID: string = await browserTabsUtil.getCurrentWindowHandle();
+		await createWorkspace.clickOnSampleNoEditorSelection(sampleName);
+		await browserTabsUtil.waitAndSwitchToAnotherWindow(parentGUID, TIMEOUT_CONSTANTS.TS_IDE_LOAD_TIMEOUT);
+
+		await waitWorkspaceReadiness();
+
+		secondWorkspaceName = WorkspaceHandlingTests.getWorkspaceName();
+		expect(secondWorkspaceName, 'Second workspace name should not be empty').not.empty;
+		expect(secondWorkspaceName, 'A new workspace with different name should be created').not.to.be.equal(firstWorkspaceName);
+	});
+
+	test('Step 6-9: Turn off "Create New", verify warning with workspace list, and select second workspace', async function (): Promise<void> {
+		await openCreateWorkspacePage();
+
+		// turn off "Create New" checkbox
+		await createWorkspace.setCreateNewWorkspaceCheckbox(false);
+		expect(await createWorkspace.isCreateNewWorkspaceCheckboxChecked(), '"Create New" checkbox should be unchecked').to.be.false;
+
+		// click on the same sample
+		const parentGUID: string = await browserTabsUtil.getCurrentWindowHandle();
+		await createWorkspace.clickOnSampleNoEditorSelection(sampleName);
+		await browserTabsUtil.waitAndSwitchToAnotherWindow(parentGUID, TIMEOUT_CONSTANTS.TS_IDE_LOAD_TIMEOUT);
+
+		// wait for existing workspace found alert with list of workspaces
+		await dashboard.waitExistingWorkspaceFoundAlert();
+
+		// select the second workspace (created at step 4)
+		await dashboard.startExistedWorkspace(secondWorkspaceName);
+
+		await workspaceHandlingTests.obtainWorkspaceNameFromStartingPage();
+		registerRunningWorkspace(WorkspaceHandlingTests.getWorkspaceName());
+
+		await projectAndFileTests.waitWorkspaceReadinessForCheCodeEditor();
+
+		// verify the second workspace was opened
+		expect(WorkspaceHandlingTests.getWorkspaceName(), 'The second workspace should be opened').to.be.equal(secondWorkspaceName);
+	});
+
+	suiteTeardown('Stop and delete all created workspaces', async function (): Promise<void> {
+		await workspaceHandlingTests.stopAndRemoveWorkspace(firstWorkspaceName);
+		await workspaceHandlingTests.stopAndRemoveWorkspace(secondWorkspaceName);
+	});
+
+	suiteTeardown('Unregister running workspace', function (): void {
+		registerRunningWorkspace('');
+	});
+});


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?

Test steps to check `create workspace from sample`:
1. Go to User Dashboard and ensure "Create New" check box is turned on by default.
2. Create a new workspace from Java Lombok sample.
3. Turn off "Create New" check box.
4. Try to create a new workspace from Java Lombok sample.
Expected behavior: the existing workspace should be opened instead of creating a duplicate workspace.
5. Turn on "Create New" check box.
6. Try to create workspace from *Java Lombok *sample.
Expected behavior: new workspace should be created without any warnings.
7. Turn off "Create New" check box.
8. Try to create workspace from Java Lombok sample.
Expected behavior: the warning message should appear, with the list of existing workspaces:
Existing workspace created from the same repository are found
9. Select workspace created at step 6.
Expected behavior: existing workspace created at step 6 should be opened.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://redhat.atlassian.net/browse/CRW-9616

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->

<details>
<summary>Test logs</summary>

```text
          ▼ Dashboard.openDashboard
            ‣ DriverHelper.navigateToUrl
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
          ▼ Dashboard.openDashboard - No alert detected
          ▼ Dashboard.waitPage
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Dashboard.waitPage
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ BrowserTabsUtil.closeAllTabsExceptCurrent
          ▼ BrowserTabsUtil.getAllWindowHandles
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.getCurrentWindowHandle
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.switchToWindow
            ‣ DriverHelper.getDriver
          ▼ Dashboard.clickCreateWorkspaceButton
            ‣ DriverHelper.waitAndClick - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ CreateWorkspace.waitPage
          ▼ CreateWorkspace.waitTitleContains - text: "Create Workspace"
            ‣ DriverHelper.waitVisibility - By(xpath, //h1[contains(text(), 'Create Workspace')])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ CreateWorkspace.isCreateNewWorkspaceCheckboxChecked
            ‣ DriverHelper.waitPresence - By(css selector, *[id="create-new-if-exist-switch"])
          ▼ BrowserTabsUtil.getCurrentWindowHandle
            ‣ DriverHelper.getDriver
          ▼ CreateWorkspace.clickOnSampleNoEditorSelection - sampleName: "Java Lombok"
            ‣ CreateWorkspace.getSampleLocator - sampleName: Java Lombok, used default editor
            ‣ DriverHelper.waitAndClick - By(xpath, //div[contains(@id, 'sample-card') and text()='Java Lombok'])
            ‣ DriverHelper.waitVisibility - By(xpath, //div[contains(@id, 'sample-card') and text()='Java Lombok'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ BrowserTabsUtil.waitAndSwitchToAnotherWindow
            ‣ DriverHelper.waitUntilTrue
          ▼ BrowserTabsUtil.getAllWindowHandles
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.getAllWindowHandles
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.switchToWindow
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - obtained starting workspace getText():Starting workspace java-lombok
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - trimmed workspace name from getText():java-lombok
      • WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - obtained workspace name from workspace loader page: java-lombok
          ▼ registerRunningWorkspace - with workspaceName:java-lombok
          ▼ ProjectAndFileTests.waitWorkspaceReadinessForCheCodeEditor - waiting for editor.
            ‣ DriverHelper.waitVisibility - By(css selector, .monaco-workbench)
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #2, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #3, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #4, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #5, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #6, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #7, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #8, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #9, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #10, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #11, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #12, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #13, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #14, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #15, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #16, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #17, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #18, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #19, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #20, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ ProjectAndFileTests.waitWorkspaceReadinessForCheCodeEditor - editor was opened in 23870 seconds.
          ▼ ProjectAndFileTests.getProjectViewSession
            ‣ DriverHelper.waitVisibility - By(css selector, .monaco-list-row)
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ ProjectAndFileTests.getProjectTreeItem - lombok-project-sample
            ‣ DriverHelper.waitVisibility - By(xpath, .//div[@role='treeitem' and @aria-level='2'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ ProjectAndFileTests.getProjectTreeItem - devfile.yaml
            ‣ DriverHelper.waitVisibility - By(xpath, .//div[@role='treeitem' and @aria-level='2'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
    ✔ Step 1-2: Verify "Create New" is on by default and create first workspace from sample (34425ms)
          ▼ Dashboard.openDashboard
            ‣ DriverHelper.navigateToUrl
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
          ▼ Dashboard.openDashboard - No alert detected
          ▼ Dashboard.waitPage
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Dashboard.waitPage
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ BrowserTabsUtil.closeAllTabsExceptCurrent
          ▼ BrowserTabsUtil.getAllWindowHandles
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.getCurrentWindowHandle
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.switchToWindow
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.switchToWindow
            ‣ DriverHelper.getDriver
          ▼ Dashboard.clickCreateWorkspaceButton
            ‣ DriverHelper.waitAndClick - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ CreateWorkspace.waitPage
          ▼ CreateWorkspace.waitTitleContains - text: "Create Workspace"
            ‣ DriverHelper.waitVisibility - By(xpath, //h1[contains(text(), 'Create Workspace')])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ CreateWorkspace.setCreateNewWorkspaceCheckbox - checked: false
          ▼ CreateWorkspace.isCreateNewWorkspaceCheckboxChecked
            ‣ DriverHelper.waitPresence - By(css selector, *[id="create-new-if-exist-switch"])
          ▼ CreateWorkspace.setCreateNewWorkspaceCheckbox - Checkbox is set, unsetting it now
            ‣ DriverHelper.wait - (5000 milliseconds)
            ‣ DriverHelper.scrollToAndClick
            ‣ DriverHelper.scrollTo - By(css selector, label[for="create-new-if-exist-switch"])
            ‣ DriverHelper.waitPresence - By(css selector, label[for="create-new-if-exist-switch"])
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.waitAndClick - By(css selector, label[for="create-new-if-exist-switch"])
            ‣ DriverHelper.waitVisibility - By(css selector, label[for="create-new-if-exist-switch"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ CreateWorkspace.isCreateNewWorkspaceCheckboxChecked
            ‣ DriverHelper.waitPresence - By(css selector, *[id="create-new-if-exist-switch"])
          ▼ BrowserTabsUtil.getCurrentWindowHandle
            ‣ DriverHelper.getDriver
          ▼ CreateWorkspace.clickOnSampleNoEditorSelection - sampleName: "Java Lombok"
            ‣ CreateWorkspace.getSampleLocator - sampleName: Java Lombok, used default editor
            ‣ DriverHelper.waitAndClick - By(xpath, //div[contains(@id, 'sample-card') and text()='Java Lombok'])
            ‣ DriverHelper.waitVisibility - By(xpath, //div[contains(@id, 'sample-card') and text()='Java Lombok'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ BrowserTabsUtil.waitAndSwitchToAnotherWindow
            ‣ DriverHelper.waitUntilTrue
          ▼ BrowserTabsUtil.getAllWindowHandles
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.getAllWindowHandles
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.switchToWindow
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - obtained starting workspace getText():Starting workspace java-lombok
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - trimmed workspace name from getText():java-lombok
      • WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - obtained workspace name from workspace loader page: java-lombok
          ▼ registerRunningWorkspace - with workspaceName:java-lombok
          ▼ ProjectAndFileTests.waitWorkspaceReadinessForCheCodeEditor - waiting for editor.
            ‣ DriverHelper.waitVisibility - By(css selector, .monaco-workbench)
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #2, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ ProjectAndFileTests.waitWorkspaceReadinessForCheCodeEditor - editor was opened in 5060 seconds.
          ▼ ProjectAndFileTests.getProjectViewSession
            ‣ DriverHelper.waitVisibility - By(css selector, .monaco-list-row)
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ ProjectAndFileTests.getProjectTreeItem - lombok-project-sample
            ‣ DriverHelper.waitVisibility - By(xpath, .//div[@role='treeitem' and @aria-level='2'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ ProjectAndFileTests.getProjectTreeItem - devfile.yaml
            ‣ DriverHelper.waitVisibility - By(xpath, .//div[@role='treeitem' and @aria-level='2'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
    ✔ Step 3: Turn off "Create New" and verify existing workspace opens
          ▼ Dashboard.openDashboard
            ‣ DriverHelper.navigateToUrl
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
          ▼ Dashboard.openDashboard - No alert detected
          ▼ Dashboard.waitPage
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Dashboard.waitPage
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ BrowserTabsUtil.closeAllTabsExceptCurrent
          ▼ BrowserTabsUtil.getAllWindowHandles
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.getCurrentWindowHandle
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.switchToWindow
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.switchToWindow
            ‣ DriverHelper.getDriver
          ▼ Dashboard.clickCreateWorkspaceButton
            ‣ DriverHelper.waitAndClick - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ CreateWorkspace.waitPage
          ▼ CreateWorkspace.waitTitleContains - text: "Create Workspace"
            ‣ DriverHelper.waitVisibility - By(xpath, //h1[contains(text(), 'Create Workspace')])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ CreateWorkspace.setCreateNewWorkspaceCheckbox - checked: true
          ▼ CreateWorkspace.isCreateNewWorkspaceCheckboxChecked
            ‣ DriverHelper.waitPresence - By(css selector, *[id="create-new-if-exist-switch"])
          ▼ CreateWorkspace.setCreateNewWorkspaceCheckbox - Checkbox is already set, no action needed
          ▼ CreateWorkspace.isCreateNewWorkspaceCheckboxChecked
            ‣ DriverHelper.waitPresence - By(css selector, *[id="create-new-if-exist-switch"])
          ▼ BrowserTabsUtil.getCurrentWindowHandle
            ‣ DriverHelper.getDriver
          ▼ CreateWorkspace.clickOnSampleNoEditorSelection - sampleName: "Java Lombok"
            ‣ CreateWorkspace.getSampleLocator - sampleName: Java Lombok, used default editor
            ‣ DriverHelper.waitAndClick - By(xpath, //div[contains(@id, 'sample-card') and text()='Java Lombok'])
            ‣ DriverHelper.waitVisibility - By(xpath, //div[contains(@id, 'sample-card') and text()='Java Lombok'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ BrowserTabsUtil.waitAndSwitchToAnotherWindow
            ‣ DriverHelper.waitUntilTrue
          ▼ BrowserTabsUtil.getAllWindowHandles
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.getAllWindowHandles
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.switchToWindow
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - obtained starting workspace getText():Starting workspace java-lombok-r0uh
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - trimmed workspace name from getText():java-lombok-r0uh
      • WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - obtained workspace name from workspace loader page: java-lombok-r0uh
          ▼ registerRunningWorkspace - with workspaceName:java-lombok-r0uh
          ▼ ProjectAndFileTests.waitWorkspaceReadinessForCheCodeEditor - waiting for editor.
            ‣ DriverHelper.waitVisibility - By(css selector, .monaco-workbench)
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #2, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #3, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #4, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #5, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #6, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #7, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #8, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #9, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #10, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #11, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #12, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #13, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #14, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #15, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #16, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #17, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ ProjectAndFileTests.waitWorkspaceReadinessForCheCodeEditor - editor was opened in 21939 seconds.
          ▼ ProjectAndFileTests.getProjectViewSession
            ‣ DriverHelper.waitVisibility - By(css selector, .monaco-list-row)
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ ProjectAndFileTests.getProjectTreeItem - lombok-project-sample
            ‣ DriverHelper.waitVisibility - By(xpath, .//div[@role='treeitem' and @aria-level='2'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ ProjectAndFileTests.getProjectTreeItem - devfile.yaml
            ‣ DriverHelper.waitVisibility - By(xpath, .//div[@role='treeitem' and @aria-level='2'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
    ✔ Step 4-5: Turn on "Create New" and verify new workspace is created without warnings (31726ms)
          ▼ Dashboard.openDashboard
            ‣ DriverHelper.navigateToUrl
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
          ▼ Dashboard.openDashboard - No alert detected
          ▼ Dashboard.waitPage
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Dashboard.waitPage
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ BrowserTabsUtil.closeAllTabsExceptCurrent
          ▼ BrowserTabsUtil.getAllWindowHandles
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.getCurrentWindowHandle
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.switchToWindow
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.switchToWindow
            ‣ DriverHelper.getDriver
          ▼ Dashboard.clickCreateWorkspaceButton
            ‣ DriverHelper.waitAndClick - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ CreateWorkspace.waitPage
          ▼ CreateWorkspace.waitTitleContains - text: "Create Workspace"
            ‣ DriverHelper.waitVisibility - By(xpath, //h1[contains(text(), 'Create Workspace')])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ CreateWorkspace.setCreateNewWorkspaceCheckbox - checked: false
          ▼ CreateWorkspace.isCreateNewWorkspaceCheckboxChecked
            ‣ DriverHelper.waitPresence - By(css selector, *[id="create-new-if-exist-switch"])
          ▼ CreateWorkspace.setCreateNewWorkspaceCheckbox - Checkbox is set, unsetting it now
            ‣ DriverHelper.wait - (5000 milliseconds)
            ‣ DriverHelper.scrollToAndClick
            ‣ DriverHelper.scrollTo - By(css selector, label[for="create-new-if-exist-switch"])
            ‣ DriverHelper.waitPresence - By(css selector, label[for="create-new-if-exist-switch"])
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.waitAndClick - By(css selector, label[for="create-new-if-exist-switch"])
            ‣ DriverHelper.waitVisibility - By(css selector, label[for="create-new-if-exist-switch"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ CreateWorkspace.isCreateNewWorkspaceCheckboxChecked
            ‣ DriverHelper.waitPresence - By(css selector, *[id="create-new-if-exist-switch"])
          ▼ BrowserTabsUtil.getCurrentWindowHandle
            ‣ DriverHelper.getDriver
          ▼ CreateWorkspace.clickOnSampleNoEditorSelection - sampleName: "Java Lombok"
            ‣ CreateWorkspace.getSampleLocator - sampleName: Java Lombok, used default editor
            ‣ DriverHelper.waitAndClick - By(xpath, //div[contains(@id, 'sample-card') and text()='Java Lombok'])
            ‣ DriverHelper.waitVisibility - By(xpath, //div[contains(@id, 'sample-card') and text()='Java Lombok'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ BrowserTabsUtil.waitAndSwitchToAnotherWindow
            ‣ DriverHelper.waitUntilTrue
          ▼ BrowserTabsUtil.getAllWindowHandles
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.getAllWindowHandles
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.switchToWindow
            ‣ DriverHelper.getDriver
          ▼ Dashboard.waitExistingWorkspaceFoundAlert
            ‣ DriverHelper.waitVisibility - By(xpath, //div[text()="Several workspaces created from the same repository have been found. Should you want to open one of the existing workspaces or create a new one, please choose the corresponding action."])
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #2, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #3, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Dashboard.startExistedWorkspace
            ‣ DriverHelper.waitVisibility - By(xpath, //button//span[text()="Open the existing workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitPresence - By(xpath, //button//span[text()="Open the existing workspace"])
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.waitAndClick - By(xpath, //li//span[text()="java-lombok-r0uh"])
            ‣ DriverHelper.waitVisibility - By(xpath, //li//span[text()="java-lombok-r0uh"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - obtained starting workspace getText():Starting workspace java-lombok-r0uh
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - trimmed workspace name from getText():java-lombok-r0uh
      • WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - obtained workspace name from workspace loader page: java-lombok-r0uh
          ▼ registerRunningWorkspace - with workspaceName:java-lombok-r0uh
          ▼ ProjectAndFileTests.waitWorkspaceReadinessForCheCodeEditor - waiting for editor.
            ‣ DriverHelper.waitVisibility - By(css selector, .monaco-workbench)
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #2, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #3, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ ProjectAndFileTests.waitWorkspaceReadinessForCheCodeEditor - editor was opened in 5135 seconds.
    ✔ Step 6-9: Turn off "Create New", verify warning with workspace list, and select second workspace
          ▼ Dashboard.openDashboard
            ‣ DriverHelper.navigateToUrl
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
          ▼ Dashboard.openDashboard - No alert detected
          ▼ Dashboard.waitPage
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Dashboard.stopAndRemoveWorkspaceByUI - "java-lombok"
          ▼ Dashboard.stopWorkspaceByUI - "java-lombok"
          ▼ Dashboard.clickWorkspacesButton
            ‣ DriverHelper.waitAndClick - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitPage
            ‣ DriverHelper.waitVisibility - By(css selector, button[aria-label="Add Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitWorkspaceListItem - "java-lombok"
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='java-lombok']])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.stopWorkspaceByActionsButton
          ▼ Workspaces.waitWorkspaceListItem - "java-lombok"
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='java-lombok']])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.openActionsPopup - for the 'java-lombok' list item
          ▼ Workspaces.clickActionsButton - of the 'java-lombok' list item
            ‣ DriverHelper.waitAndClick - By(xpath, //tr[td//span[text()='java-lombok']]/td/button[@aria-label='Actions for java-lombok'])
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='java-lombok']]/td/button[@aria-label='Actions for java-lombok'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitActionsPopup - of the 'java-lombok' list item
            ‣ DriverHelper.waitVisibility - By(css selector, div[class*="workspaceActionSelector"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.clickActionsStopWorkspaceButton - for the 'java-lombok' list item
            ‣ DriverHelper.waitAndClick - By(css selector, button[aria-label="Action: Stop Workspace"])
            ‣ DriverHelper.waitVisibility - By(css selector, button[aria-label="Action: Stop Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitWorkspaceWithStoppedStatus - "java-lombok"
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='java-lombok']]//span[@data-testid='workspace-status-indicator' and @aria-label='Workspace status is Stopped'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Dashboard.deleteStoppedWorkspaceByUI - "java-lombok"
          ▼ Dashboard.clickWorkspacesButton
            ‣ DriverHelper.waitAndClick - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitPage
            ‣ DriverHelper.waitVisibility - By(css selector, button[aria-label="Add Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitWorkspaceListItem - "java-lombok"
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='java-lombok']])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.deleteWorkspaceByActionsButton
          ▼ Workspaces.waitWorkspaceListItem - "java-lombok"
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='java-lombok']])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.openActionsPopup - for the 'java-lombok' list item
          ▼ Workspaces.clickActionsButton - of the 'java-lombok' list item
            ‣ DriverHelper.waitAndClick - By(xpath, //tr[td//span[text()='java-lombok']]/td/button[@aria-label='Actions for java-lombok'])
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='java-lombok']]/td/button[@aria-label='Actions for java-lombok'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitActionsPopup - of the 'java-lombok' list item
            ‣ DriverHelper.waitVisibility - By(css selector, div[class*="workspaceActionSelector"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.clickActionsDeleteButton - for the 'java-lombok' list item
            ‣ DriverHelper.waitAndClick - By(css selector, button[aria-label="Action: Delete Workspace"])
            ‣ DriverHelper.waitVisibility - By(css selector, button[aria-label="Action: Delete Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitDeleteWorkspaceConfirmationWindow
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@aria-label="Delete workspaces confirmation window"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.clickToDeleteConfirmationCheckbox
            ‣ DriverHelper.waitAndClick - By(xpath, //input[@data-testid="confirmation-checkbox"])
            ‣ DriverHelper.waitVisibility - By(xpath, //input[@data-testid="confirmation-checkbox"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitAndClickEnabledConfirmationWindowDeleteButton
            ‣ DriverHelper.waitAndClick - By(xpath, //button[@data-testid="delete-workspace-button" and not(@disabled)])
            ‣ DriverHelper.waitVisibility - By(xpath, //button[@data-testid="delete-workspace-button" and not(@disabled)])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitPage
            ‣ DriverHelper.waitVisibility - By(css selector, button[aria-label="Add Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitWorkspaceListItemAbsence - "java-lombok"
            ‣ DriverHelper.waitDisappearance - By(xpath, //tr[td//span[text()='java-lombok']])
            ‣ DriverHelper.waitDisappearanceBoolean - By(xpath, //tr[td//span[text()='java-lombok']])
            ‣ DriverHelper.isVisible - By(xpath, //tr[td//span[text()='java-lombok']])
          ▼ Dashboard.openDashboard
            ‣ DriverHelper.navigateToUrl
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
          ▼ Dashboard.openDashboard - No alert detected
          ▼ Dashboard.waitPage
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Dashboard.stopAndRemoveWorkspaceByUI - "java-lombok-r0uh"
          ▼ Dashboard.stopWorkspaceByUI - "java-lombok-r0uh"
          ▼ Dashboard.clickWorkspacesButton
            ‣ DriverHelper.waitAndClick - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitPage
            ‣ DriverHelper.waitVisibility - By(css selector, button[aria-label="Add Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitWorkspaceListItem - "java-lombok-r0uh"
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='java-lombok-r0uh']])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.stopWorkspaceByActionsButton
          ▼ Workspaces.waitWorkspaceListItem - "java-lombok-r0uh"
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='java-lombok-r0uh']])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.openActionsPopup - for the 'java-lombok-r0uh' list item
          ▼ Workspaces.clickActionsButton - of the 'java-lombok-r0uh' list item
            ‣ DriverHelper.waitAndClick - By(xpath, //tr[td//span[text()='java-lombok-r0uh']]/td/button[@aria-label='Actions for java-lombok-r0uh'])
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='java-lombok-r0uh']]/td/button[@aria-label='Actions for java-lombok-r0uh'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitActionsPopup - of the 'java-lombok-r0uh' list item
            ‣ DriverHelper.waitVisibility - By(css selector, div[class*="workspaceActionSelector"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.clickActionsStopWorkspaceButton - for the 'java-lombok-r0uh' list item
            ‣ DriverHelper.waitAndClick - By(css selector, button[aria-label="Action: Stop Workspace"])
            ‣ DriverHelper.waitVisibility - By(css selector, button[aria-label="Action: Stop Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitWorkspaceWithStoppedStatus - "java-lombok-r0uh"
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='java-lombok-r0uh']]//span[@data-testid='workspace-status-indicator' and @aria-label='Workspace status is Stopped'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Dashboard.deleteStoppedWorkspaceByUI - "java-lombok-r0uh"
          ▼ Dashboard.clickWorkspacesButton
            ‣ DriverHelper.waitAndClick - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitPage
            ‣ DriverHelper.waitVisibility - By(css selector, button[aria-label="Add Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitWorkspaceListItem - "java-lombok-r0uh"
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='java-lombok-r0uh']])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.deleteWorkspaceByActionsButton
          ▼ Workspaces.waitWorkspaceListItem - "java-lombok-r0uh"
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='java-lombok-r0uh']])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.openActionsPopup - for the 'java-lombok-r0uh' list item
          ▼ Workspaces.clickActionsButton - of the 'java-lombok-r0uh' list item
            ‣ DriverHelper.waitAndClick - By(xpath, //tr[td//span[text()='java-lombok-r0uh']]/td/button[@aria-label='Actions for java-lombok-r0uh'])
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='java-lombok-r0uh']]/td/button[@aria-label='Actions for java-lombok-r0uh'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitActionsPopup - of the 'java-lombok-r0uh' list item
            ‣ DriverHelper.waitVisibility - By(css selector, div[class*="workspaceActionSelector"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.clickActionsDeleteButton - for the 'java-lombok-r0uh' list item
            ‣ DriverHelper.waitAndClick - By(css selector, button[aria-label="Action: Delete Workspace"])
            ‣ DriverHelper.waitVisibility - By(css selector, button[aria-label="Action: Delete Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitDeleteWorkspaceConfirmationWindow
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@aria-label="Delete workspaces confirmation window"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.clickToDeleteConfirmationCheckbox
            ‣ DriverHelper.waitAndClick - By(xpath, //input[@data-testid="confirmation-checkbox"])
            ‣ DriverHelper.waitVisibility - By(xpath, //input[@data-testid="confirmation-checkbox"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitAndClickEnabledConfirmationWindowDeleteButton
            ‣ DriverHelper.waitAndClick - By(xpath, //button[@data-testid="delete-workspace-button" and not(@disabled)])
            ‣ DriverHelper.waitVisibility - By(xpath, //button[@data-testid="delete-workspace-button" and not(@disabled)])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitPage
            ‣ DriverHelper.waitVisibility - By(css selector, button[aria-label="Add Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitWorkspaceListItemAbsence - "java-lombok-r0uh"
            ‣ DriverHelper.waitDisappearance - By(xpath, //tr[td//span[text()='java-lombok-r0uh']])
            ‣ DriverHelper.waitDisappearanceBoolean - By(xpath, //tr[td//span[text()='java-lombok-r0uh']])
            ‣ DriverHelper.isVisible - By(xpath, //tr[td//span[text()='java-lombok-r0uh']])
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.isVisible - By(xpath, //tr[td//span[text()='java-lombok-r0uh']])
          ▼     at /che/tests/e2e/specs/MochaHooks.ts:39:12 - delete workspace name


  4 passing (2m)
```

</details>

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
