### PR TITLE
Handle "Workspace Trust" popup in VS Code Editor E2E typescript tests

### DIFF
--- a/tests/e2e/pageobjects/ide/RestrictedModeButton.ts
+++ b/tests/e2e/pageobjects/ide/RestrictedModeButton.ts
@@ -17,6 +17,7 @@ import { Logger } from '../../utils/Logger';
 @injectable()
 export class RestrictedModeButton {
 	private static readonly RESTRICTED_MODE_BUTTON: By = By.id('status.workspaceTrust');
+	private static readonly CLOSE_RESTRICTED_MODE_WINDOW: By = By.css('a[aria-label="Close Modal Editor (Escape)"]');
 
 	constructor(
 		@inject(CLASSES.DriverHelper)
@@ -27,6 +28,12 @@ export class RestrictedModeButton {
 		Logger.debug();
 
 		await this.driverHelper.waitAndClick(RestrictedModeButton.RESTRICTED_MODE_BUTTON);
+	}
+
+	async closeRestrictedModeWindow(): Promise<void> {
+		Logger.debug();
+
+		await this.driverHelper.waitAndClick(RestrictedModeButton.CLOSE_RESTRICTED_MODE_WINDOW);
 	}
 
 	async isRestrictedModeButtonDisappearance(): Promise<void> {

--- a/tests/e2e/specs/factory/SshUrlNoOauthPatFactory.spec.ts
+++ b/tests/e2e/specs/factory/SshUrlNoOauthPatFactory.spec.ts
@@ -57,7 +57,7 @@ suite(`The SshUrlNoOauthPatFactory userstory ${BASE_TEST_CONSTANTS.TEST_ENVIRONM
 	let scmContextMenu: ContextMenu;
 	let viewsActionsButton: boolean;
 	// test specific data
-	const timeToRefresh: number = 1500;
+	const timeToRefresh: number = 2500;
 	const changesToCommit: string = 'Commit ' + new Date().getTime().toString();
 	const fileToChange: string = 'Date.txt';
 	const refreshButtonLabel: string = 'Refresh';
@@ -139,6 +139,7 @@ suite(`The SshUrlNoOauthPatFactory userstory ${BASE_TEST_CONSTANTS.TEST_ENVIRONM
 			await driverHelper.getDriver().actions().sendKeys(Key.DELETE).perform();
 			await driverHelper.wait(1000);
 			Logger.debug(`Entering text: "${changesToCommit}"`);
+			await driverHelper.wait(2000);
 			await driverHelper.getDriver().actions().sendKeys(changesToCommit).perform();
 		});
 

--- a/tests/e2e/tests-library/ProjectAndFileTests.ts
+++ b/tests/e2e/tests-library/ProjectAndFileTests.ts
@@ -92,6 +92,7 @@ export class ProjectAndFileTests {
 					(this.cheCodeLocatorLoader.webCheCodeLocators.Workbench as any).workspaceTrustButton,
 					TIMEOUT_CONSTANTS.TS_DIALOG_WINDOW_DEFAULT_TIMEOUT
 				);
+				await this.restrictedModeButton.closeRestrictedModeWindow();
 			} catch (e) {
 				Logger.info('Restricted Mode button or Trusted Workspace box was not shown');
 			}


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
We need to fix E2E typescript tests which failed because didn’t handle properly following popups:
<img width="1024" height="500" alt="8606f131-9abd-44e6-9350-7da5efe0f926" src="https://github.com/user-attachments/assets/71836af8-9d3b-46ce-a42a-5d96c6a78e58" />

Also add the **SshUrlNoOauthPatFactory** test stabilization fix.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://redhat.atlassian.net/browse/CRW-11675

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
Validated on **SshUrlNoOauthPatFactory** e2e test:

>  
            ‣ DriverHelper.waitAndClick - By(css selector, *[id="status\.workspaceTrust"])
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="status\.workspaceTrust"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitAndClick - By(xpath, //a[@role="button" and text()="Trust"])
            ‣ DriverHelper.waitVisibility - By(xpath, //a[@role="button" and text()="Trust"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
                RestrictedModeButton.closeRestrictedModeWindow
            ‣ DriverHelper.waitAndClick - By(css selector, a[aria-label="Close Modal Editor (Escape)"])
            ‣ DriverHelper.waitVisibility - By(css selector, a[aria-label="Close Modal Editor (Escape)"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
