### PR TITLE
Add workspace trust dialog handling to BuildPushRunPodmanContainerAPI and Kubedock/Podman E2E tests

### DIFF
--- a/tests/e2e/specs/api/BuildPushRunPodmanContainerAPI.spec.ts
+++ b/tests/e2e/specs/api/BuildPushRunPodmanContainerAPI.spec.ts
@@ -134,6 +134,7 @@ oc logs test-hello-pod
 			await projectAndFileTests.getProjectTreeItem(projectSection, 'Dockerfile.x86_64'),
 			'Dockerfile not found in the project tree'
 		).not.undefined;
+		await projectAndFileTests.performTrustDialogs();
 	});
 
 	test('Build and push container image from workspace', function (): void {

--- a/tests/e2e/specs/miscellaneous/KubedockPodmanPersistUserHomeTest.spec.ts
+++ b/tests/e2e/specs/miscellaneous/KubedockPodmanPersistUserHomeTest.spec.ts
@@ -120,6 +120,7 @@ suite(`Test image build with persistUserHome enabled (kubedock and podman) ${BAS
 	test('Check the project files were imported', async function (): Promise<void> {
 		const projectSection: ViewSection = await projectAndFileTests.getProjectViewSession();
 		expect(await projectAndFileTests.getProjectTreeItem(projectSection, 'Dockerfile.ppc64le'), 'Files not imported').not.undefined;
+		await projectAndFileTests.performTrustDialogs();
 	});
 
 	test('Create and check container runs using kubedock and podman with persistUserHome', function (): void {

--- a/tests/e2e/specs/miscellaneous/KubedockPodmanTest.spec.ts
+++ b/tests/e2e/specs/miscellaneous/KubedockPodmanTest.spec.ts
@@ -107,6 +107,7 @@ suite(
 		test('Check the project files were imported', async function (): Promise<void> {
 			const projectSection: ViewSection = await projectAndFileTests.getProjectViewSession();
 			expect(await projectAndFileTests.getProjectTreeItem(projectSection, 'Dockerfile.ppc64le'), 'Files not imported').not.undefined;
+			await projectAndFileTests.performTrustDialogs();
 		});
 
 		test('Create and check container runs using kubedock and podman', function (): void {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Workspace trust dialogs are not handled in the Podman-related E2E specs. Other factory/sample tests already accept trust dialogs after workspace readiness (e.g. `SshUrlNoOauthPatFactory`, `Quarkus`), but these specs skip that step.

Without accepting the trust dialogs, project tree checks and follow-up actions can be flaky or blocked by VS Code / Che Code trust prompts.

 Affected tests:

- `tests/e2e/specs/api/BuildPushRunPodmanContainerAPI.spec.ts`
- `tests/e2e/specs/miscellaneous/KubedockPodmanTest.spec.ts`
- `tests/e2e/specs/miscellaneous/KubedockPodmanPersistUserHomeTest.spec.ts`

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://redhat.atlassian.net/browse/CRW-11941

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
