### PR TITLE
Stabilize SshUrlNoOauthPatFactory SSH key input and editor interactions

### DIFF
--- a/tests/e2e/pageobjects/dashboard/UserPreferences.ts
+++ b/tests/e2e/pageobjects/dashboard/UserPreferences.ts
@@ -212,7 +212,7 @@ export class UserPreferences {
 
 		Logger.info('Pasting private SSH key');
 		await this.driverHelper.waitAndClick(UserPreferences.PASTE_PRIVATE_SSH_KEY_FIELD);
-		await this.driverHelper.getAction().sendKeys(privateSshKey).perform();
+		await this.driverHelper.type(UserPreferences.PASTE_PRIVATE_SSH_KEY_FIELD, privateSshKey);
 
 		// verify private SSH key was correctly set
 		const enteredPrivateKey: string = await this.driverHelper.waitAndGetValue(
@@ -225,8 +225,8 @@ export class UserPreferences {
 		Logger.info('Private SSH key verified successfully');
 
 		Logger.info('Pasting public SSH key');
-		await this.driverHelper.waitAndClick(UserPreferences.PASTE_PUBLIC_SSH_KEY_FIELD);
-		await this.driverHelper.getAction().sendKeys(publicSshKey).perform();
+		await this.driverHelper.waitAndClick(UserPreferences.PASTE_PRIVATE_SSH_KEY_FIELD);
+		await this.driverHelper.type(UserPreferences.PASTE_PUBLIC_SSH_KEY_FIELD, publicSshKey);
 
 		// verify public SSH key was correctly set
 		const enteredPublicKey: string = await this.driverHelper.waitAndGetValue(

--- a/tests/e2e/pageobjects/dashboard/UserPreferences.ts
+++ b/tests/e2e/pageobjects/dashboard/UserPreferences.ts
@@ -225,7 +225,7 @@ export class UserPreferences {
 		Logger.info('Private SSH key verified successfully');
 
 		Logger.info('Pasting public SSH key');
-		await this.driverHelper.waitAndClick(UserPreferences.PASTE_PRIVATE_SSH_KEY_FIELD);
+		await this.driverHelper.waitAndClick(UserPreferences.PASTE_PUBLIC_SSH_KEY_FIELD);
 		await this.driverHelper.type(UserPreferences.PASTE_PUBLIC_SSH_KEY_FIELD, publicSshKey);
 
 		// verify public SSH key was correctly set

--- a/tests/e2e/specs/factory/SshUrlNoOauthPatFactory.spec.ts
+++ b/tests/e2e/specs/factory/SshUrlNoOauthPatFactory.spec.ts
@@ -134,10 +134,10 @@ suite(`The SshUrlNoOauthPatFactory userstory ${BASE_TEST_CONSTANTS.TEST_ENVIRONM
 
 			Logger.debug('Clearing the editor with Ctrl+A');
 			await driverHelper.getDriver().actions().keyDown(Key.CONTROL).sendKeys('a').keyUp(Key.CONTROL).perform();
-			await driverHelper.wait(1000);
+			await driverHelper.wait(2000);
 			Logger.debug('Deleting selected text');
 			await driverHelper.getDriver().actions().sendKeys(Key.DELETE).perform();
-			await driverHelper.wait(1000);
+			await driverHelper.wait(2000);
 			Logger.debug(`Entering text: "${changesToCommit}"`);
 			await driverHelper.wait(2000);
 			await driverHelper.getDriver().actions().sendKeys(changesToCommit).perform();


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
## Summary
- Paste SSH keys in User Preferences via `DriverHelper.type()` instead of Actions `sendKeys`, so private/public key values are entered more reliably.
- Increase short waits while clearing/editing `Date.txt` in `SshUrlNoOauthPatFactory` to reduce flaky editor interactions before commit/push.


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://redhat.atlassian.net/browse/CRW-12019

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
- [ ] Run `SshUrlNoOauthPatFactory` with SSH keys from env vars (`TS_SELENIUM_SSH_PRIVATE_KEY` / `TS_SELENIUM_SSH_PUBLIC_KEY`)
- [ ] Confirm “Add SSH keys” verifies private/public key fields successfully
- [ ] Confirm project import, file edit, commit, and push steps pass


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
