### PR TITLE
Fix AnsibleDevfileApiTest failure after empty command exec code

### DIFF
--- a/tests/e2e/specs/api/AnsibleDevFileAPI.spec.ts
+++ b/tests/e2e/specs/api/AnsibleDevFileAPI.spec.ts
@@ -91,14 +91,16 @@ suite('Ansible devfile API test', function (): void {
 		const output: ShellString = containerTerminal.execInContainerCommand(runCommandInBash, containerName);
 		expect(output.code).eqls(0);
 
-		const recapBlocks: string[] = output.stdout.split(/PLAY RECAP/g).slice(1);
+		// molecule may write its rich formatted output (box-drawing, ANSI codes) to stderr rather than stdout (CRW-12595)
+		const combinedOutput: string = (output.stdout + output.stderr).trim();
+
+		const recapBlocks: string[] = combinedOutput.split(/PLAY RECAP/g).slice(1);
 		recapBlocks.forEach((block): void => {
 			expect(block).match(/failed\s*=\s*0/);
 		});
 
-		const outputText: string = output.stdout.trim();
-		expect(outputText).to.include('was installed successfully');
-		expect(outputText).to.not.match(/failed\s*=\s*[1-9]\d*/);
+		expect(combinedOutput).to.include('was installed successfully');
+		expect(combinedOutput).to.not.match(/failed\s*=\s*[1-9]\d*/);
 	});
 
 	test('Check "molecule-list" command', function (): void {

--- a/tests/e2e/specs/api/AnsibleDevFileAPI.spec.ts
+++ b/tests/e2e/specs/api/AnsibleDevFileAPI.spec.ts
@@ -125,7 +125,8 @@ suite('Ansible devfile API test', function (): void {
 		const output: ShellString = containerTerminal.execInContainerCommand(runCommandInBash, containerName);
 		expect(output.code).eqls(0);
 
-		const outputText: string = output.stdout.trim();
+		// molecule may write its rich formatted output (box-drawing, ANSI codes) to stderr rather than stdout
+		const outputText: string = (output.stdout + output.stderr).trim();
 		expect(outputText).to.include('molecule');
 		expect(outputText).to.include('ansible');
 		expect(outputText).to.include('default');
@@ -154,14 +155,16 @@ suite('Ansible devfile API test', function (): void {
 		const output: ShellString = containerTerminal.execInContainerCommand(runCommandInBash, containerName);
 		expect(output.code).eqls(0);
 
-		const recapBlocks: string[] = output.stdout.split(/PLAY RECAP/g).slice(1);
+		// molecule may write its rich formatted output (box-drawing, ANSI codes) to stderr rather than stdout
+		const combinedOutput: string = (output.stdout + output.stderr).trim();
+
+		const recapBlocks: string[] = combinedOutput.split(/PLAY RECAP/g).slice(1);
 		recapBlocks.forEach((block): void => {
 			expect(block).match(/failed\s*=\s*0/);
 		});
 
-		const outputText: string = output.stdout.trim();
-		expect(outputText).to.include('PLAY [Converge]');
-		expect(outputText).to.not.match(/failed\s*=\s*[1-9]\d*/);
+		expect(combinedOutput).to.include('PLAY [Converge]');
+		expect(combinedOutput).to.not.match(/failed\s*=\s*[1-9]\d*/);
 	});
 
 	test('Check "molecule-verify" command', function (): void {
@@ -186,14 +189,16 @@ suite('Ansible devfile API test', function (): void {
 		const output: ShellString = containerTerminal.execInContainerCommand(runCommandInBash, containerName);
 		expect(output.code).eqls(0);
 
-		const recapBlocks: string[] = output.stdout.split(/PLAY RECAP/g).slice(1);
+		// molecule may write its rich formatted output (box-drawing, ANSI codes) to stderr rather than stdout
+		const combinedOutput: string = (output.stdout + output.stderr).trim();
+
+		const recapBlocks: string[] = combinedOutput.split(/PLAY RECAP/g).slice(1);
 		recapBlocks.forEach((block): void => {
 			expect(block).match(/failed\s*=\s*0/);
 		});
 
-		const outputText: string = output.stdout.trim();
-		expect(outputText).to.include('PLAY [Verify]');
-		expect(outputText).to.not.match(/failed\s*=\s*[1-9]\d*/);
+		expect(combinedOutput).to.include('PLAY [Verify]');
+		expect(combinedOutput).to.not.match(/failed\s*=\s*[1-9]\d*/);
 	});
 
 	test('Check "molecule-destroy" command', function (): void {
@@ -218,14 +223,16 @@ suite('Ansible devfile API test', function (): void {
 		const output: ShellString = containerTerminal.execInContainerCommand(runCommandInBash, containerName);
 		expect(output.code).eqls(0);
 
-		const recapBlocks: string[] = output.stdout.split(/PLAY RECAP/g).slice(1);
+		// molecule may write its rich formatted output (box-drawing, ANSI codes) to stderr rather than stdout
+		const combinedOutput: string = (output.stdout + output.stderr).trim();
+
+		const recapBlocks: string[] = combinedOutput.split(/PLAY RECAP/g).slice(1);
 		recapBlocks.forEach((block): void => {
 			expect(block).match(/failed\s*=\s*0/);
 		});
 
-		const outputText: string = output.stdout.trim();
-		expect(outputText).to.include('PLAY [Destroy]');
-		expect(outputText).to.not.match(/failed\s*=\s*[1-9]\d*/);
+		expect(combinedOutput).to.include('PLAY [Destroy]');
+		expect(combinedOutput).to.not.match(/failed\s*=\s*[1-9]\d*/);
 	});
 
 	test('Check "molecule-test" command', function (): void {
@@ -250,16 +257,18 @@ suite('Ansible devfile API test', function (): void {
 		const output: ShellString = containerTerminal.execInContainerCommand(runCommandInBash, containerName);
 		expect(output.code).eqls(0);
 
-		const recapBlocks: string[] = output.stdout.split(/PLAY RECAP/g).slice(1);
+		// molecule may write its rich formatted output (box-drawing, ANSI codes) to stderr rather than stdout
+		const combinedOutput: string = (output.stdout + output.stderr).trim();
+
+		const recapBlocks: string[] = combinedOutput.split(/PLAY RECAP/g).slice(1);
 		recapBlocks.forEach((block): void => {
 			expect(block).match(/failed\s*=\s*0/);
 		});
 
-		const outputText: string = output.stdout.trim();
-		expect(outputText).to.include('PLAY [Create]');
-		expect(outputText).to.include('PLAY [Converge]');
-		expect(outputText).to.include('PLAY [Verify]');
-		expect(outputText).to.not.match(/failed\s*=\s*[1-9]\d*/);
+		expect(combinedOutput).to.include('PLAY [Create]');
+		expect(combinedOutput).to.include('PLAY [Converge]');
+		expect(combinedOutput).to.include('PLAY [Verify]');
+		expect(combinedOutput).to.not.match(/failed\s*=\s*[1-9]\d*/);
 	});
 
 	test('Check "ansible-navigator" command', function (): void {
@@ -300,7 +309,8 @@ suite('Ansible devfile API test', function (): void {
 		const output: ShellString = containerTerminal.execInContainerCommand(runCommandInBash, containerName);
 		expect(output.code).eqls(0);
 
-		const outputText: string = output.stdout.trim();
+		// ansible-navigator may write output to stderr depending on terminal detection
+		const outputText: string = (output.stdout + output.stderr).trim();
 		expect(outputText).to.include('ansible-navigator');
 		expect(outputText).to.include('collections');
 		expect(outputText).to.include('config');

--- a/tests/e2e/utils/KubernetesCommandLineToolsExecutor.ts
+++ b/tests/e2e/utils/KubernetesCommandLineToolsExecutor.ts
@@ -176,7 +176,7 @@ export class KubernetesCommandLineToolsExecutor implements IKubernetesCommandLin
 		Logger.debug(`${this.kubernetesCommandLineTool}`);
 
 		return this.shellExecutor.executeCommand(
-			`${this.kubernetesCommandLineTool} exec -i -t ${KubernetesCommandLineToolsExecutor.pod} -n ${this.namespace} -c ${container} -- sh -c '${commandToExecute}'`
+			`${this.kubernetesCommandLineTool} exec -i ${KubernetesCommandLineToolsExecutor.pod} -n ${this.namespace} -c ${container} -- sh -c '${commandToExecute}'`
 		);
 	}
 


### PR DESCRIPTION
### What does this PR do?
Fixes AnsibleDevFileAPI test failure `AssertionError: expected '' to include 'was installed successfully'`.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?
https://redhat.atlassian.net/browse/CRW-12595


### How to test this PR?
Successful test runs
- https://jenkins-csb-crwqe-main.dno.corp.redhat.com/job/Testing/job/e2e/job/basic/job/api-tests/19341/
- https://jenkins-csb-crwqe-main.dno.corp.redhat.com/job/Testing/job/e2e/job/basic/job/api-tests/19342/


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

--
Assisted-by Claude Code
