### PR TITLE
Update CreateWorkspaceWithExistingNameFromGitUrl for Create New Workspace behavior

### DIFF
--- a/tests/e2e/specs/miscellaneous/CreateWorkspaceWithExistingNameFromGitUrl.spec.ts
+++ b/tests/e2e/specs/miscellaneous/CreateWorkspaceWithExistingNameFromGitUrl.spec.ts
@@ -75,7 +75,7 @@ suite(`"Start workspace with existed workspace name" test ${BASE_TEST_CONSTANTS.
 		await waitDashboardPage();
 
 		await createWorkspace.setGitRepositoryUrl(factoryUrl);
-		await createWorkspace.waitForCheckboxState(false);
+		await createWorkspace.waitForCheckboxState(true);
 		expect(await createWorkspace.getGitRepositoryUrl()).to.be.equal(factoryUrl);
 		await createWorkspace.clickOnCreateAndOpenButton();
 		await createWorkspace.performTrustAuthorPopup();
@@ -89,6 +89,7 @@ suite(`"Start workspace with existed workspace name" test ${BASE_TEST_CONSTANTS.
 		await waitDashboardPage();
 
 		await createWorkspace.setGitRepositoryUrl(factoryUrl);
+		await createWorkspace.setCreateNewWorkspaceCheckbox(false);
 		expect(await createWorkspace.getGitRepositoryUrl()).to.be.equal(factoryUrl);
 		await createWorkspace.clickOnCreateAndOpenButton();
 		await createWorkspace.performTrustAuthorPopup();
@@ -102,11 +103,8 @@ suite(`"Start workspace with existed workspace name" test ${BASE_TEST_CONSTANTS.
 		await waitDashboardPage();
 
 		await createWorkspace.setGitRepositoryUrl(factoryUrl);
-		await createWorkspace.waitForCheckboxState(false);
-		await createWorkspace.setCreateNewWorkspaceCheckbox(true);
 		await createWorkspace.waitForCheckboxState(true);
-
-		expect(await createWorkspace.getGitRepositoryUrl()).to.be.equal(factoryUrl + '?new');
+		await createWorkspace.setCreateNewWorkspaceCheckbox(true);
 
 		await createWorkspace.clickOnCreateAndOpenButton();
 		await createWorkspace.performTrustAuthorPopup();
@@ -122,6 +120,7 @@ suite(`"Start workspace with existed workspace name" test ${BASE_TEST_CONSTANTS.
 		await waitDashboardPage();
 
 		await createWorkspace.setGitRepositoryUrl(factoryUrl);
+		await createWorkspace.setCreateNewWorkspaceCheckbox(false);
 		await createWorkspace.clickOnCreateAndOpenButton();
 		await createWorkspace.performTrustAuthorPopup();
 		const originalWindowHandle: string = await browserTabsUtil.getCurrentWindowHandle();


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Updates the CreateWorkspaceWithExistingNameFromGitUrl E2E test to align with the dashboard fix in [eclipse-che/che-dashboard#1656](https://github.com/eclipse-che/che-dashboard/pull/1656), which changed how the "Create New" switch behaves when a URL is entered in the Import from Git field.

### Why is this needed?
After [eclipse-che/che-dashboard#1656](https://github.com/eclipse-che/che-dashboard/pull/1656), the "Create New" switch is no longer silently reset to OFF when a Git URL is entered — it stays ON by default. Additionally, the ?new query parameter is now injected at click-time instead of being appended to the input field URL. These behavioral changes broke several E2E test assertions.

### Changes

- Expect checkbox ON after entering URL: changed waitForCheckboxState(false) → waitForCheckboxState(true), since the switch now preserves its default ON state.
- Explicitly set checkbox OFF for redirect scenarios: added setCreateNewWorkspaceCheckbox(false) before steps that expect redirect to an existing workspace, since the switch no longer resets automatically.
- Remove ?new URL assertion: removed expect(url).to.be.equal(factoryUrl + '?new') because ?new is now injected at click-time by the dashboard, not appended to the input field value.
- Simplify "create new with checkbox ON" step: removed redundant toggle-on/wait sequence since the switch is already ON by default.


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://redhat.atlassian.net/browse/CRW-13005

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Test logs
<details>
<summary>Test log</summary>

```text
          ▼ Dashboard.openDashboard
            ‣ DriverHelper.navigateToUrl
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
          ▼ Dashboard.openDashboard - No alert detected
          ▼ Dashboard.waitPage
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Dashboard.waitPage
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ BrowserTabsUtil.closeAllTabsExceptCurrent
          ▼ BrowserTabsUtil.getAllWindowHandles
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.getCurrentWindowHandle
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.switchToWindow
            ‣ DriverHelper.getDriver
          ▼ Dashboard.clickCreateWorkspaceButton
            ‣ DriverHelper.waitAndClick - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ CreateWorkspace.waitPage
          ▼ CreateWorkspace.waitTitleContains - text: "Create Workspace"
            ‣ DriverHelper.waitVisibility - By(xpath, //h1[contains(text(), 'Create Workspace')])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ CreateWorkspace.isCreateNewWorkspaceCheckboxChecked
            ‣ DriverHelper.waitPresence - By(css selector, *[id="create-new-if-exist-switch"])
          ▼ CreateWorkspace.setGitRepositoryUrl - factoryUrl: "https://github.com/crw-qe/python-hello-world"
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="git-repo-url"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.type - By(css selector, *[id="git-repo-url"]) text: https://github.com/crw-qe/python-hello-world
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="git-repo-url"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ CreateWorkspace.getGitRepositoryUrl
            ‣ DriverHelper.waitAndGetValue - By(css selector, *[id="git-repo-url"])
            ‣ DriverHelper.waitAndGetElementAttribute - By(css selector, *[id="git-repo-url"]) attribute: 'value'
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="git-repo-url"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
      • CreateWorkspace.setGitRepositoryUrl - [INFO] Git repository URL set to "https://github.com/crw-qe/python-hello-world"
          ▼ CreateWorkspace.waitForCheckboxState - waiting for checkbox to be checked
          ▼ CreateWorkspace.isCreateNewWorkspaceCheckboxChecked
            ‣ DriverHelper.waitPresence - By(css selector, *[id="create-new-if-exist-switch"])
          ▼ CreateWorkspace.waitForCheckboxState - Checkbox reached expected state: true
          ▼ CreateWorkspace.getGitRepositoryUrl
            ‣ DriverHelper.waitAndGetValue - By(css selector, *[id="git-repo-url"])
            ‣ DriverHelper.waitAndGetElementAttribute - By(css selector, *[id="git-repo-url"]) attribute: 'value'
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="git-repo-url"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ CreateWorkspace.clickOnCreateAndOpenButton
            ‣ DriverHelper.waitAndClick - By(css selector, *[id="create-and-open-button"])
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="create-and-open-button"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ CreateWorkspace.performTrustAuthorPopup
          ▼ TrustAuthorPopup.clickContinue
          ▼ TrustAuthorPopup.waitPopupIsOpened
            ‣ DriverHelper.waitVisibility - By(xpath, //span[contains(text(), "Do you trust the authors of this repository?")])
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #2, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #3, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #4, retrying with 1000ms timeout
  [ERROR] DriverHelper.waitVisibility - failed with exception, out of attempts - TimeoutError: Waiting for element to be located By(xpath, //span[contains(text(), "Do you trust the authors of this repository?")])
  Wait timed out after 1044ms
      • CreateWorkspace.performTrustAuthorPopup - "Trust author" popup was not shown
          ▼ BrowserTabsUtil.getCurrentWindowHandle
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.waitAndSwitchToAnotherWindow
            ‣ DriverHelper.waitUntilTrue
          ▼ BrowserTabsUtil.getAllWindowHandles
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.getAllWindowHandles
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.switchToWindow
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - obtained starting workspace getText():Starting workspace python-hello-world
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - trimmed workspace name from getText():python-hello-world
      • WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - obtained workspace name from workspace loader page: python-hello-world
          ▼ registerRunningWorkspace - with workspaceName:python-hello-world
          ▼ ProjectAndFileTests.waitWorkspaceReadinessForCheCodeEditor - waiting for editor.
            ‣ DriverHelper.waitVisibility - By(css selector, .monaco-workbench)
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #2, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #3, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #4, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #5, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #6, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #7, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #8, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #9, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #10, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #11, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #12, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #13, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #14, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #15, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #16, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #17, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #18, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #19, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #20, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #21, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #22, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #23, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #24, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #25, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #26, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #27, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #28, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #29, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #30, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #31, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #32, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #33, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ ProjectAndFileTests.waitWorkspaceReadinessForCheCodeEditor - editor was opened in 39048 seconds.
          ▼ ProjectAndFileTests.dismissAiCodeSignInDialog
          ▼ AiCodeSignInDialog.isDialogVisible
            ‣ DriverHelper.waitVisibilityBoolean - By(css selector, div.onboarding-a-overlay.visible)
            ‣ DriverHelper.isVisible - By(css selector, div.onboarding-a-overlay.visible)
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.isVisible - By(css selector, div.onboarding-a-overlay.visible)
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.isVisible - By(css selector, div.onboarding-a-overlay.visible)
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.isVisible - By(css selector, div.onboarding-a-overlay.visible)
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.isVisible - By(css selector, div.onboarding-a-overlay.visible)
            ‣ DriverHelper.wait - (1000 milliseconds)
          ▼ ProjectAndFileTests.getProjectViewSession
            ‣ DriverHelper.waitVisibility - By(css selector, .monaco-list-row)
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ ProjectAndFileTests.getProjectTreeItem - python-hello-world
            ‣ DriverHelper.waitVisibility - By(xpath, .//div[@role='treeitem' and @aria-level='2'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ ProjectAndFileTests.getProjectTreeItem - devfile.yaml
            ‣ DriverHelper.waitVisibility - By(xpath, .//div[@role='treeitem' and @aria-level='2'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
    ✔ Verify "Create New" is off and a new workspace is created (58605ms)
          ▼ Dashboard.openDashboard
            ‣ DriverHelper.navigateToUrl
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
          ▼ Dashboard.openDashboard - No alert detected
          ▼ Dashboard.waitPage
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Dashboard.waitPage
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ BrowserTabsUtil.closeAllTabsExceptCurrent
          ▼ BrowserTabsUtil.getAllWindowHandles
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.getCurrentWindowHandle
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.switchToWindow
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.switchToWindow
            ‣ DriverHelper.getDriver
          ▼ Dashboard.clickCreateWorkspaceButton
            ‣ DriverHelper.waitAndClick - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ CreateWorkspace.waitPage
          ▼ CreateWorkspace.waitTitleContains - text: "Create Workspace"
            ‣ DriverHelper.waitVisibility - By(xpath, //h1[contains(text(), 'Create Workspace')])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ CreateWorkspace.isCreateNewWorkspaceCheckboxChecked
            ‣ DriverHelper.waitPresence - By(css selector, *[id="create-new-if-exist-switch"])
          ▼ CreateWorkspace.setGitRepositoryUrl - factoryUrl: "https://github.com/crw-qe/python-hello-world"
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="git-repo-url"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.type - By(css selector, *[id="git-repo-url"]) text: https://github.com/crw-qe/python-hello-world
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="git-repo-url"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ CreateWorkspace.getGitRepositoryUrl
            ‣ DriverHelper.waitAndGetValue - By(css selector, *[id="git-repo-url"])
            ‣ DriverHelper.waitAndGetElementAttribute - By(css selector, *[id="git-repo-url"]) attribute: 'value'
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="git-repo-url"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
      • CreateWorkspace.setGitRepositoryUrl - [INFO] Git repository URL set to "https://github.com/crw-qe/python-hello-world"
          ▼ CreateWorkspace.setCreateNewWorkspaceCheckbox - checked: false
          ▼ CreateWorkspace.isCreateNewWorkspaceCheckboxChecked
            ‣ DriverHelper.waitPresence - By(css selector, *[id="create-new-if-exist-switch"])
          ▼ CreateWorkspace.setCreateNewWorkspaceCheckbox - Checkbox is set, unsetting it now
            ‣ DriverHelper.wait - (5000 milliseconds)
            ‣ DriverHelper.scrollToAndClick
            ‣ DriverHelper.scrollTo - By(css selector, label[for="create-new-if-exist-switch"])
            ‣ DriverHelper.waitPresence - By(css selector, label[for="create-new-if-exist-switch"])
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.waitAndClick - By(css selector, label[for="create-new-if-exist-switch"])
            ‣ DriverHelper.waitVisibility - By(css selector, label[for="create-new-if-exist-switch"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ CreateWorkspace.getGitRepositoryUrl
            ‣ DriverHelper.waitAndGetValue - By(css selector, *[id="git-repo-url"])
            ‣ DriverHelper.waitAndGetElementAttribute - By(css selector, *[id="git-repo-url"]) attribute: 'value'
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="git-repo-url"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ CreateWorkspace.clickOnCreateAndOpenButton
            ‣ DriverHelper.waitAndClick - By(css selector, *[id="create-and-open-button"])
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="create-and-open-button"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ CreateWorkspace.performTrustAuthorPopup
          ▼ TrustAuthorPopup.clickContinue
          ▼ TrustAuthorPopup.waitPopupIsOpened
            ‣ DriverHelper.waitVisibility - By(xpath, //span[contains(text(), "Do you trust the authors of this repository?")])
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #2, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #3, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #4, retrying with 1000ms timeout
  [ERROR] DriverHelper.waitVisibility - failed with exception, out of attempts - TimeoutError: Waiting for element to be located By(xpath, //span[contains(text(), "Do you trust the authors of this repository?")])
  Wait timed out after 1055ms
      • CreateWorkspace.performTrustAuthorPopup - "Trust author" popup was not shown
          ▼ BrowserTabsUtil.getCurrentWindowHandle
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.waitAndSwitchToAnotherWindow
            ‣ DriverHelper.waitUntilTrue
          ▼ BrowserTabsUtil.getAllWindowHandles
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.getAllWindowHandles
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.switchToWindow
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - obtained starting workspace getText():Starting workspace python-hello-world
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - trimmed workspace name from getText():python-hello-world
      • WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - obtained workspace name from workspace loader page: python-hello-world
          ▼ registerRunningWorkspace - with workspaceName:python-hello-world
          ▼ ProjectAndFileTests.waitWorkspaceReadinessForCheCodeEditor - waiting for editor.
            ‣ DriverHelper.waitVisibility - By(css selector, .monaco-workbench)
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #2, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ ProjectAndFileTests.waitWorkspaceReadinessForCheCodeEditor - editor was opened in 10942 seconds.
          ▼ ProjectAndFileTests.dismissAiCodeSignInDialog
          ▼ AiCodeSignInDialog.isDialogVisible
            ‣ DriverHelper.waitVisibilityBoolean - By(css selector, div.onboarding-a-overlay.visible)
            ‣ DriverHelper.isVisible - By(css selector, div.onboarding-a-overlay.visible)
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.isVisible - By(css selector, div.onboarding-a-overlay.visible)
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.isVisible - By(css selector, div.onboarding-a-overlay.visible)
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.isVisible - By(css selector, div.onboarding-a-overlay.visible)
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.isVisible - By(css selector, div.onboarding-a-overlay.visible)
            ‣ DriverHelper.wait - (1000 milliseconds)
          ▼ ProjectAndFileTests.getProjectViewSession
            ‣ DriverHelper.waitVisibility - By(css selector, .monaco-list-row)
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ ProjectAndFileTests.getProjectTreeItem - python-hello-world
            ‣ DriverHelper.waitVisibility - By(xpath, .//div[@role='treeitem' and @aria-level='2'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ ProjectAndFileTests.getProjectTreeItem - devfile.yaml
            ‣ DriverHelper.waitVisibility - By(xpath, .//div[@role='treeitem' and @aria-level='2'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
    ✔ Verify existing workspace opens instead of creating a duplicate (33532ms)
          ▼ Dashboard.openDashboard
            ‣ DriverHelper.navigateToUrl
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
          ▼ Dashboard.openDashboard - No alert detected
          ▼ Dashboard.waitPage
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Dashboard.waitPage
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ BrowserTabsUtil.closeAllTabsExceptCurrent
          ▼ BrowserTabsUtil.getAllWindowHandles
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.getCurrentWindowHandle
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.switchToWindow
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.switchToWindow
            ‣ DriverHelper.getDriver
          ▼ Dashboard.clickCreateWorkspaceButton
            ‣ DriverHelper.waitAndClick - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ CreateWorkspace.waitPage
          ▼ CreateWorkspace.waitTitleContains - text: "Create Workspace"
            ‣ DriverHelper.waitVisibility - By(xpath, //h1[contains(text(), 'Create Workspace')])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ CreateWorkspace.isCreateNewWorkspaceCheckboxChecked
            ‣ DriverHelper.waitPresence - By(css selector, *[id="create-new-if-exist-switch"])
          ▼ CreateWorkspace.setGitRepositoryUrl - factoryUrl: "https://github.com/crw-qe/python-hello-world"
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="git-repo-url"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.type - By(css selector, *[id="git-repo-url"]) text: https://github.com/crw-qe/python-hello-world
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="git-repo-url"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ CreateWorkspace.getGitRepositoryUrl
            ‣ DriverHelper.waitAndGetValue - By(css selector, *[id="git-repo-url"])
            ‣ DriverHelper.waitAndGetElementAttribute - By(css selector, *[id="git-repo-url"]) attribute: 'value'
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="git-repo-url"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
      • CreateWorkspace.setGitRepositoryUrl - [INFO] Git repository URL set to "https://github.com/crw-qe/python-hello-world"
          ▼ CreateWorkspace.waitForCheckboxState - waiting for checkbox to be checked
          ▼ CreateWorkspace.isCreateNewWorkspaceCheckboxChecked
            ‣ DriverHelper.waitPresence - By(css selector, *[id="create-new-if-exist-switch"])
          ▼ CreateWorkspace.waitForCheckboxState - Checkbox reached expected state: true
          ▼ CreateWorkspace.setCreateNewWorkspaceCheckbox - checked: true
          ▼ CreateWorkspace.isCreateNewWorkspaceCheckboxChecked
            ‣ DriverHelper.waitPresence - By(css selector, *[id="create-new-if-exist-switch"])
          ▼ CreateWorkspace.setCreateNewWorkspaceCheckbox - Checkbox is already set, no action needed
          ▼ CreateWorkspace.clickOnCreateAndOpenButton
            ‣ DriverHelper.waitAndClick - By(css selector, *[id="create-and-open-button"])
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="create-and-open-button"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ CreateWorkspace.performTrustAuthorPopup
          ▼ TrustAuthorPopup.clickContinue
          ▼ TrustAuthorPopup.waitPopupIsOpened
            ‣ DriverHelper.waitVisibility - By(xpath, //span[contains(text(), "Do you trust the authors of this repository?")])
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #2, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #3, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #4, retrying with 1000ms timeout
  [ERROR] DriverHelper.waitVisibility - failed with exception, out of attempts - TimeoutError: Waiting for element to be located By(xpath, //span[contains(text(), "Do you trust the authors of this repository?")])
  Wait timed out after 1042ms
      • CreateWorkspace.performTrustAuthorPopup - "Trust author" popup was not shown
          ▼ BrowserTabsUtil.getCurrentWindowHandle
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.waitAndSwitchToAnotherWindow
            ‣ DriverHelper.waitUntilTrue
          ▼ BrowserTabsUtil.getAllWindowHandles
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.getAllWindowHandles
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.switchToWindow
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - obtained starting workspace getText():Starting workspace python-hello-world-vxpq
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - trimmed workspace name from getText():python-hello-world-vxpq
      • WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - obtained workspace name from workspace loader page: python-hello-world-vxpq
          ▼ registerRunningWorkspace - with workspaceName:python-hello-world-vxpq
          ▼ ProjectAndFileTests.waitWorkspaceReadinessForCheCodeEditor - waiting for editor.
            ‣ DriverHelper.waitVisibility - By(css selector, .monaco-workbench)
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #2, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #3, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #4, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #5, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #6, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #7, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #8, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #9, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #10, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #11, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #12, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #13, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #14, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #15, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #16, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #17, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #18, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #19, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #20, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #21, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #22, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #23, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #24, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #25, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #26, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #27, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #28, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #29, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #30, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #31, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #32, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #33, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #34, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #35, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #36, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ ProjectAndFileTests.waitWorkspaceReadinessForCheCodeEditor - editor was opened in 42181 seconds.
          ▼ ProjectAndFileTests.dismissAiCodeSignInDialog
          ▼ AiCodeSignInDialog.isDialogVisible
            ‣ DriverHelper.waitVisibilityBoolean - By(css selector, div.onboarding-a-overlay.visible)
            ‣ DriverHelper.isVisible - By(css selector, div.onboarding-a-overlay.visible)
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.isVisible - By(css selector, div.onboarding-a-overlay.visible)
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.isVisible - By(css selector, div.onboarding-a-overlay.visible)
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.isVisible - By(css selector, div.onboarding-a-overlay.visible)
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.isVisible - By(css selector, div.onboarding-a-overlay.visible)
            ‣ DriverHelper.wait - (1000 milliseconds)
          ▼ ProjectAndFileTests.getProjectViewSession
            ‣ DriverHelper.waitVisibility - By(css selector, .monaco-list-row)
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ ProjectAndFileTests.getProjectTreeItem - python-hello-world
            ‣ DriverHelper.waitVisibility - By(xpath, .//div[@role='treeitem' and @aria-level='2'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ ProjectAndFileTests.getProjectTreeItem - devfile.yaml
            ‣ DriverHelper.waitVisibility - By(xpath, .//div[@role='treeitem' and @aria-level='2'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
    ✔ Ensure `new` is appended and a new workspace is created without warnings (58603ms)
          ▼ Dashboard.openDashboard
            ‣ DriverHelper.navigateToUrl
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
          ▼ Dashboard.openDashboard - No alert detected
          ▼ Dashboard.waitPage
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Dashboard.waitPage
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ BrowserTabsUtil.closeAllTabsExceptCurrent
          ▼ BrowserTabsUtil.getAllWindowHandles
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.getCurrentWindowHandle
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.switchToWindow
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.switchToWindow
            ‣ DriverHelper.getDriver
          ▼ Dashboard.clickCreateWorkspaceButton
            ‣ DriverHelper.waitAndClick - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ CreateWorkspace.waitPage
          ▼ CreateWorkspace.waitTitleContains - text: "Create Workspace"
            ‣ DriverHelper.waitVisibility - By(xpath, //h1[contains(text(), 'Create Workspace')])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ CreateWorkspace.isCreateNewWorkspaceCheckboxChecked
            ‣ DriverHelper.waitPresence - By(css selector, *[id="create-new-if-exist-switch"])
          ▼ CreateWorkspace.setGitRepositoryUrl - factoryUrl: "https://github.com/crw-qe/python-hello-world"
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="git-repo-url"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.type - By(css selector, *[id="git-repo-url"]) text: https://github.com/crw-qe/python-hello-world
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="git-repo-url"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ CreateWorkspace.getGitRepositoryUrl
            ‣ DriverHelper.waitAndGetValue - By(css selector, *[id="git-repo-url"])
            ‣ DriverHelper.waitAndGetElementAttribute - By(css selector, *[id="git-repo-url"]) attribute: 'value'
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="git-repo-url"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
      • CreateWorkspace.setGitRepositoryUrl - [INFO] Git repository URL set to "https://github.com/crw-qe/python-hello-world"
          ▼ CreateWorkspace.setCreateNewWorkspaceCheckbox - checked: false
          ▼ CreateWorkspace.isCreateNewWorkspaceCheckboxChecked
            ‣ DriverHelper.waitPresence - By(css selector, *[id="create-new-if-exist-switch"])
          ▼ CreateWorkspace.setCreateNewWorkspaceCheckbox - Checkbox is set, unsetting it now
            ‣ DriverHelper.wait - (5000 milliseconds)
            ‣ DriverHelper.scrollToAndClick
            ‣ DriverHelper.scrollTo - By(css selector, label[for="create-new-if-exist-switch"])
            ‣ DriverHelper.waitPresence - By(css selector, label[for="create-new-if-exist-switch"])
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.waitAndClick - By(css selector, label[for="create-new-if-exist-switch"])
            ‣ DriverHelper.waitVisibility - By(css selector, label[for="create-new-if-exist-switch"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ CreateWorkspace.clickOnCreateAndOpenButton
            ‣ DriverHelper.waitAndClick - By(css selector, *[id="create-and-open-button"])
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="create-and-open-button"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ CreateWorkspace.performTrustAuthorPopup
          ▼ TrustAuthorPopup.clickContinue
          ▼ TrustAuthorPopup.waitPopupIsOpened
            ‣ DriverHelper.waitVisibility - By(xpath, //span[contains(text(), "Do you trust the authors of this repository?")])
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #2, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #3, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #4, retrying with 1000ms timeout
  [ERROR] DriverHelper.waitVisibility - failed with exception, out of attempts - TimeoutError: Waiting for element to be located By(xpath, //span[contains(text(), "Do you trust the authors of this repository?")])
  Wait timed out after 1057ms
      • CreateWorkspace.performTrustAuthorPopup - "Trust author" popup was not shown
          ▼ BrowserTabsUtil.getCurrentWindowHandle
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.waitAndSwitchToAnotherWindow
            ‣ DriverHelper.waitUntilTrue
          ▼ BrowserTabsUtil.getAllWindowHandles
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.getAllWindowHandles
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.switchToWindow
            ‣ DriverHelper.getDriver
          ▼ Dashboard.waitExistingWorkspaceFoundAlert
            ‣ DriverHelper.waitVisibility - By(xpath, //div[text()="Several workspaces created from the same repository have been found. Should you want to open one of the existing workspaces or create a new one, please choose the corresponding action."])
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Dashboard.startExistedWorkspace
            ‣ DriverHelper.waitVisibility - By(xpath, //button//span[text()="Open the existing workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitPresence - By(xpath, //button//span[text()="Open the existing workspace"])
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.waitAndClick - By(xpath, //li//span[text()="python-hello-world"])
            ‣ DriverHelper.waitVisibility - By(xpath, //li//span[text()="python-hello-world"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - obtained starting workspace getText():Starting workspace python-hello-world
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - trimmed workspace name from getText():python-hello-world
      • WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - obtained workspace name from workspace loader page: python-hello-world
          ▼ registerRunningWorkspace - with workspaceName:python-hello-world
          ▼ ProjectAndFileTests.waitWorkspaceReadinessForCheCodeEditor - waiting for editor.
            ‣ DriverHelper.waitVisibility - By(css selector, .monaco-workbench)
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #2, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ ProjectAndFileTests.waitWorkspaceReadinessForCheCodeEditor - editor was opened in 13837 seconds.
          ▼ ProjectAndFileTests.dismissAiCodeSignInDialog
          ▼ AiCodeSignInDialog.isDialogVisible
            ‣ DriverHelper.waitVisibilityBoolean - By(css selector, div.onboarding-a-overlay.visible)
            ‣ DriverHelper.isVisible - By(css selector, div.onboarding-a-overlay.visible)
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.isVisible - By(css selector, div.onboarding-a-overlay.visible)
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.isVisible - By(css selector, div.onboarding-a-overlay.visible)
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.isVisible - By(css selector, div.onboarding-a-overlay.visible)
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.isVisible - By(css selector, div.onboarding-a-overlay.visible)
            ‣ DriverHelper.wait - (1000 milliseconds)
          ▼ ProjectAndFileTests.getProjectViewSession
            ‣ DriverHelper.waitVisibility - By(css selector, .monaco-list-row)
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ ProjectAndFileTests.getProjectTreeItem - python-hello-world
            ‣ DriverHelper.waitVisibility - By(xpath, .//div[@role='treeitem' and @aria-level='2'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ ProjectAndFileTests.getProjectTreeItem - devfile.yaml
            ‣ DriverHelper.waitVisibility - By(xpath, .//div[@role='treeitem' and @aria-level='2'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
    ✔ Verify warning appears with list of existing workspaces and open the first created workspace (38577ms)
          ▼ Dashboard.openDashboard
            ‣ DriverHelper.navigateToUrl
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
          ▼ Dashboard.openDashboard - No alert detected
          ▼ Dashboard.waitPage
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Dashboard.stopAndRemoveWorkspaceByUI - "python-hello-world"
          ▼ Dashboard.stopWorkspaceByUI - "python-hello-world"
          ▼ Dashboard.clickWorkspacesButton
            ‣ DriverHelper.waitAndClick - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitPage
            ‣ DriverHelper.waitVisibility - By(css selector, button[aria-label="Add Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitWorkspaceListItem - "python-hello-world"
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='python-hello-world']])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.stopWorkspaceByActionsButton
          ▼ Workspaces.waitWorkspaceListItem - "python-hello-world"
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='python-hello-world']])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.openActionsPopup - for the 'python-hello-world' list item
          ▼ Workspaces.clickActionsButton - of the 'python-hello-world' list item
            ‣ DriverHelper.waitAndClick - By(xpath, //tr[td//span[text()='python-hello-world']]/td/button[@aria-label='Actions for python-hello-world'])
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='python-hello-world']]/td/button[@aria-label='Actions for python-hello-world'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitActionsPopup - of the 'python-hello-world' list item
            ‣ DriverHelper.waitVisibility - By(css selector, div[class*="workspaceActionSelector"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.clickActionsStopWorkspaceButton - for the 'python-hello-world' list item
            ‣ DriverHelper.waitAndClick - By(css selector, button[aria-label="Action: Stop Workspace"])
            ‣ DriverHelper.waitVisibility - By(css selector, button[aria-label="Action: Stop Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitWorkspaceWithStoppedStatus - "python-hello-world"
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='python-hello-world']]//span[@data-testid='workspace-status-indicator' and @aria-label='Workspace status is Stopped'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Dashboard.deleteStoppedWorkspaceByUI - "python-hello-world"
          ▼ Dashboard.clickWorkspacesButton
            ‣ DriverHelper.waitAndClick - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitPage
            ‣ DriverHelper.waitVisibility - By(css selector, button[aria-label="Add Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitWorkspaceListItem - "python-hello-world"
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='python-hello-world']])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.deleteWorkspaceByActionsButton
          ▼ Workspaces.waitWorkspaceListItem - "python-hello-world"
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='python-hello-world']])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.openActionsPopup - for the 'python-hello-world' list item
          ▼ Workspaces.clickActionsButton - of the 'python-hello-world' list item
            ‣ DriverHelper.waitAndClick - By(xpath, //tr[td//span[text()='python-hello-world']]/td/button[@aria-label='Actions for python-hello-world'])
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='python-hello-world']]/td/button[@aria-label='Actions for python-hello-world'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitActionsPopup - of the 'python-hello-world' list item
            ‣ DriverHelper.waitVisibility - By(css selector, div[class*="workspaceActionSelector"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.clickActionsDeleteButton - for the 'python-hello-world' list item
            ‣ DriverHelper.waitAndClick - By(css selector, button[aria-label="Action: Delete Workspace"])
            ‣ DriverHelper.waitVisibility - By(css selector, button[aria-label="Action: Delete Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitDeleteWorkspaceConfirmationWindow
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@aria-label="Delete workspaces confirmation window"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.clickToDeleteConfirmationCheckbox
            ‣ DriverHelper.waitAndClick - By(xpath, //input[@data-testid="confirmation-checkbox"])
            ‣ DriverHelper.waitVisibility - By(xpath, //input[@data-testid="confirmation-checkbox"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitAndClickEnabledConfirmationWindowDeleteButton
            ‣ DriverHelper.waitAndClick - By(xpath, //button[@data-testid="delete-workspace-button" and not(@disabled)])
            ‣ DriverHelper.waitVisibility - By(xpath, //button[@data-testid="delete-workspace-button" and not(@disabled)])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitPage
            ‣ DriverHelper.waitVisibility - By(css selector, button[aria-label="Add Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitWorkspaceListItemAbsence - "python-hello-world"
            ‣ DriverHelper.waitDisappearance - By(xpath, //tr[td//span[text()='python-hello-world']])
            ‣ DriverHelper.waitDisappearanceBoolean - By(xpath, //tr[td//span[text()='python-hello-world']])
            ‣ DriverHelper.isVisible - By(xpath, //tr[td//span[text()='python-hello-world']])
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.isVisible - By(xpath, //tr[td//span[text()='python-hello-world']])
          ▼ Dashboard.openDashboard
            ‣ DriverHelper.navigateToUrl
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
          ▼ Dashboard.openDashboard - No alert detected
          ▼ Dashboard.waitPage
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Dashboard.stopAndRemoveWorkspaceByUI - "python-hello-world-vxpq"
          ▼ Dashboard.stopWorkspaceByUI - "python-hello-world-vxpq"
          ▼ Dashboard.clickWorkspacesButton
            ‣ DriverHelper.waitAndClick - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitPage
            ‣ DriverHelper.waitVisibility - By(css selector, button[aria-label="Add Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitWorkspaceListItem - "python-hello-world-vxpq"
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='python-hello-world-vxpq']])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.stopWorkspaceByActionsButton
          ▼ Workspaces.waitWorkspaceListItem - "python-hello-world-vxpq"
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='python-hello-world-vxpq']])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.openActionsPopup - for the 'python-hello-world-vxpq' list item
          ▼ Workspaces.clickActionsButton - of the 'python-hello-world-vxpq' list item
            ‣ DriverHelper.waitAndClick - By(xpath, //tr[td//span[text()='python-hello-world-vxpq']]/td/button[@aria-label='Actions for python-hello-world-vxpq'])
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='python-hello-world-vxpq']]/td/button[@aria-label='Actions for python-hello-world-vxpq'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitActionsPopup - of the 'python-hello-world-vxpq' list item
            ‣ DriverHelper.waitVisibility - By(css selector, div[class*="workspaceActionSelector"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.clickActionsStopWorkspaceButton - for the 'python-hello-world-vxpq' list item
            ‣ DriverHelper.waitAndClick - By(css selector, button[aria-label="Action: Stop Workspace"])
            ‣ DriverHelper.waitVisibility - By(css selector, button[aria-label="Action: Stop Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitWorkspaceWithStoppedStatus - "python-hello-world-vxpq"
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='python-hello-world-vxpq']]//span[@data-testid='workspace-status-indicator' and @aria-label='Workspace status is Stopped'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Dashboard.deleteStoppedWorkspaceByUI - "python-hello-world-vxpq"
          ▼ Dashboard.clickWorkspacesButton
            ‣ DriverHelper.waitAndClick - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitPage
            ‣ DriverHelper.waitVisibility - By(css selector, button[aria-label="Add Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitWorkspaceListItem - "python-hello-world-vxpq"
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='python-hello-world-vxpq']])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.deleteWorkspaceByActionsButton
          ▼ Workspaces.waitWorkspaceListItem - "python-hello-world-vxpq"
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='python-hello-world-vxpq']])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.openActionsPopup - for the 'python-hello-world-vxpq' list item
          ▼ Workspaces.clickActionsButton - of the 'python-hello-world-vxpq' list item
            ‣ DriverHelper.waitAndClick - By(xpath, //tr[td//span[text()='python-hello-world-vxpq']]/td/button[@aria-label='Actions for python-hello-world-vxpq'])
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//span[text()='python-hello-world-vxpq']]/td/button[@aria-label='Actions for python-hello-world-vxpq'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitActionsPopup - of the 'python-hello-world-vxpq' list item
            ‣ DriverHelper.waitVisibility - By(css selector, div[class*="workspaceActionSelector"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.clickActionsDeleteButton - for the 'python-hello-world-vxpq' list item
            ‣ DriverHelper.waitAndClick - By(css selector, button[aria-label="Action: Delete Workspace"])
            ‣ DriverHelper.waitVisibility - By(css selector, button[aria-label="Action: Delete Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitDeleteWorkspaceConfirmationWindow
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@aria-label="Delete workspaces confirmation window"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.clickToDeleteConfirmationCheckbox
            ‣ DriverHelper.waitAndClick - By(xpath, //input[@data-testid="confirmation-checkbox"])
            ‣ DriverHelper.waitVisibility - By(xpath, //input[@data-testid="confirmation-checkbox"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitAndClickEnabledConfirmationWindowDeleteButton
            ‣ DriverHelper.waitAndClick - By(xpath, //button[@data-testid="delete-workspace-button" and not(@disabled)])
            ‣ DriverHelper.waitVisibility - By(xpath, //button[@data-testid="delete-workspace-button" and not(@disabled)])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitPage
            ‣ DriverHelper.waitVisibility - By(css selector, button[aria-label="Add Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitWorkspaceListItemAbsence - "python-hello-world-vxpq"
            ‣ DriverHelper.waitDisappearance - By(xpath, //tr[td//span[text()='python-hello-world-vxpq']])
            ‣ DriverHelper.waitDisappearanceBoolean - By(xpath, //tr[td//span[text()='python-hello-world-vxpq']])
            ‣ DriverHelper.isVisible - By(xpath, //tr[td//span[text()='python-hello-world-vxpq']])
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.isVisible - By(xpath, //tr[td//span[text()='python-hello-world-vxpq']])
          ▼     at /home/sskoryk/codenvy-projects/che/tests/e2e/specs/MochaHooks.ts:39:12 - delete workspace name


  4 passing (4m)
...
</details> ```

