### PR TITLE
fix: select first container in getContainerName to avoid malformed oc exec

### DIFF
--- a/tests/e2e/utils/KubernetesCommandLineToolsExecutor.ts
+++ b/tests/e2e/utils/KubernetesCommandLineToolsExecutor.ts
@@ -81,7 +81,7 @@ export class KubernetesCommandLineToolsExecutor implements IKubernetesCommandLin
 		Logger.debug(`Getting container name for pod: '${KubernetesCommandLineToolsExecutor.pod}' in namespace: ${this.namespace}`);
 
 		const output: ShellString = this.shellExecutor.executeCommand(
-			`${this.kubernetesCommandLineTool} get pod ${KubernetesCommandLineToolsExecutor.pod} -o jsonpath='{.spec.containers[*].name}' -n ${this.namespace}`
+			`${this.kubernetesCommandLineTool} get pod ${KubernetesCommandLineToolsExecutor.pod} -o jsonpath='{.spec.containers[0].name}' -n ${this.namespace}`
 		);
 		echo('\n');
 		const containerName: string = output.stderr ? output.stderr : output.stdout;


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Fixes **KubernetesCommandLineToolsExecutor.getContainerName()** to return only the first container name instead of all container names in a pod.

The **jsonpath {.spec.containers[*].name}** returns all container names space-separated (e.g. "**che-code-runtime-description che-gateway**"). This entire string was stored as a single container name and passed to kubectl exec -c, producing commands like: **kubectl exec -i <pod> -n <ns> -c che-code-runtime-description che-gateway -- sh -c '...'**
where -c only consumed the first token and **che-gateway** became a stray positional argument. This worked by luck but is incorrect.

**Fix**
Change the **jsonpath** from **{.spec.containers[*].name}** to **{.spec.containers[0].name}** so only the first container name is returned. With PR check checking it will be **dev** container.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://redhat.atlassian.net/browse/CRW-13014

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

<details>
<summary>Test log</summary>

```text
            ‣ DriverHelper.getDriver
  Empty workspace API test
          ▼ DevWorkspaceConfigurationHelper.generateDevfileContext
No plug-in registry url. Setting to https://eclipse-che.github.io/che-plugin-registry/main/v3
Validating devfile
Devfile is valid with schema version 2.2.0
(node:258578) Warning: Setting the NODE_TLS_REJECT_UNAUTHORIZED environment variable to '0' makes TLS connections and HTTPS requests insecure by disabling certificate verification.
(Use `node --trace-warnings ...` to show where the warning was created)
DevWorkspace che-code-empty-939 was generated
          ▼ DevWorkspaceConfigurationHelper.addMissedDevWorkspaceConfigAttributes
          ▼ KubernetesCommandLineToolsExecutor.loginToOcp - oc - login to the "OC" client.
          ▼ KubernetesCommandLineToolsExecutor.getServerUrl - oc - get server api url.
          ▼ KubernetesCommandLineToolsExecutor.isUserLoggedIn - oc
          ▼ ShellExecutor.executeCommand - oc whoami && oc whoami --show-server=true
admin
https://api.ocp422-sskoryk.crw-qe.com:6443
          ▼ KubernetesCommandLineToolsExecutor.getServerUrl - oc - get server api url.
          ▼ KubernetesCommandLineToolsExecutor.loginToOcp - oc - user already logged
          ▼ DevWorkspaceConfigurationHelper.getDevWorkspaceConfigurationYamlAsString
          ▼ KubernetesCommandLineToolsExecutor.applyAndWaitDevWorkspace - oc
          ▼ KubernetesCommandLineToolsExecutor.applyYamlConfigurationAsStringOutput - oc
          ▼ ShellExecutor.executeCommand - oc apply -n admin-devspaces -f /tmp/devfile-9181.yaml && rm -f /tmp/devfile-9181.yaml
devworkspacetemplate.workspace.devfile.io/che-code-empty-939 created
devworkspace.workspace.devfile.io/empty-939 created
          ▼ KubernetesCommandLineToolsExecutor.waitDevWorkspace - oc - wait till workspace ready.
          ▼ ShellExecutor.executeCommand - oc wait -n admin-devspaces --for=condition=Ready dw empty-939 --timeout=360s
devworkspace.workspace.devfile.io/empty-939 condition met
          ▼ KubernetesCommandLineToolsExecutor.getPodAndContainerNames - oc
          ▼ KubernetesCommandLineToolsExecutor.getWorkspacePodName - oc - get workspace pod name.
          ▼ KubernetesCommandLineToolsExecutor.getWorkspacePodName - Looking for pod with label: controller.devfile.io/devworkspace_name=empty-939 in namespace: admin-devspaces
          ▼ ShellExecutor.executeCommand - oc get pod -l controller.devfile.io/devworkspace_name=empty-939 -n admin-devspaces -o name
pod/workspaceb53ae7ea3a24430c-6c788b87bb-r24l6
          ▼ KubernetesCommandLineToolsExecutor.getWorkspacePodName - Found pod name (before removing prefix): 'pod/workspaceb53ae7ea3a24430c-6c788b87bb-r24l6'
          ▼ KubernetesCommandLineToolsExecutor.getWorkspacePodName - Clean pod name (after removing prefix): 'workspaceb53ae7ea3a24430c-6c788b87bb-r24l6'
          ▼ KubernetesCommandLineToolsExecutor.getContainerName - oc - get container name.
          ▼ KubernetesCommandLineToolsExecutor.getContainerName - Getting container name for pod: 'workspaceb53ae7ea3a24430c-6c788b87bb-r24l6' in namespace: admin-devspaces
          ▼ ShellExecutor.executeCommand - oc get pod workspaceb53ae7ea3a24430c-6c788b87bb-r24l6 -o jsonpath='{.spec.containers[0].name}' -n admin-devspaces
che-code-runtime-description

          ▼ KubernetesCommandLineToolsExecutor.getContainerName - Found container name: 'che-code-runtime-description'
    ✔ Create empty workspace (65722ms)
    Clone public repo without previous setup 
          ▼ ContainerTerminal.execInContainerCommand - oc
          ▼ ShellExecutor.executeCommand - oc exec -i workspaceb53ae7ea3a24430c-6c788b87bb-r24l6 -n admin-devspaces -c che-code-runtime-description -- sh -c 'pwd'
/projects
          ▼ ContainerTerminal.execInContainerCommand - oc
          ▼ ShellExecutor.executeCommand - oc exec -i workspaceb53ae7ea3a24430c-6c788b87bb-r24l6 -n admin-devspaces -c che-code-runtime-description -- sh -c 'git clone https://github.com/crw-qe/web-nodejs-sample'
Cloning into 'web-nodejs-sample'...
      ✔ Check if public repo can be cloned
          ▼ Function.getProjectNameFromGitUrl - Original URL: https://github.com/crw-qe/web-nodejs-sample
          ▼ Function.getProjectNameFromGitUrl - Extracted project name: web-nodejs-sample
          ▼ ContainerTerminal.execInContainerCommand - oc
          ▼ ShellExecutor.executeCommand - oc exec -i workspaceb53ae7ea3a24430c-6c788b87bb-r24l6 -n admin-devspaces -c che-code-runtime-description -- sh -c 'ls '
web-nodejs-sample
      ✔ Check if project was created
          ▼ ContainerTerminal.execInContainerCommand - oc
          ▼ ShellExecutor.executeCommand - oc exec -i workspaceb53ae7ea3a24430c-6c788b87bb-r24l6 -n admin-devspaces -c che-code-runtime-description -- sh -c 'ls /projects/web-nodejs-sample'
LICENSE
README.md
app
devfile.yaml
package-lock.json
package.json
      ✔ Check if project files are imported
          ▼ KubernetesCommandLineToolsExecutor.deleteDevWorkspace - oc - delete 'empty-939' devWorkspace
          ▼ ShellExecutor.executeCommand - oc patch dw empty-939 -n admin-devspaces -p '{ "metadata": { "finalizers": null }}' --type merge || true
devworkspace.workspace.devfile.io/empty-939 patched
          ▼ ShellExecutor.executeCommand - oc delete dw empty-939 -n admin-devspaces || true
devworkspace.workspace.devfile.io "empty-939" deleted from admin-devspaces namespace
          ▼ KubernetesCommandLineToolsExecutor.deleteDevWorkspace - oc - delete 'che-code-empty-939' devWorkspaceTemplate
          ▼ ShellExecutor.executeCommand - oc delete dwt che-code-empty-939 -n admin-devspaces || true
devworkspacetemplate.workspace.devfile.io "che-code-empty-939" deleted from admin-devspaces namespace


  4 passing (1m)
...
</details> ```
